### PR TITLE
Fix playback modal stutters and add stutter diagnostics

### DIFF
--- a/scripts/verifyPlaybackVisibleRange.mjs
+++ b/scripts/verifyPlaybackVisibleRange.mjs
@@ -1,0 +1,158 @@
+// Verifies computePlaybackVisibleRange matches a brute-force reference implementation.
+
+function getChordPosition(index, scrollPositions, chordRepetitions, totalWidth) {
+  return (
+    (scrollPositions[index] ?? 0) + (chordRepetitions[index] ?? 0) * totalWidth
+  );
+}
+
+function lowerBound(positions, target, start, end) {
+  let lo = start;
+  let hi = end;
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if ((positions[mid] ?? 0) < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+function upperBound(positions, target, start, end) {
+  let lo = start;
+  let hi = end;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if ((positions[mid] ?? 0) > target) hi = mid - 1;
+    else lo = mid;
+  }
+  return lo;
+}
+
+function computePlaybackVisibleRange(args) {
+  const {
+    scrollPositions,
+    chordRepetitions,
+    totalWidth,
+    currentChordIndex,
+    visiblePlaybackContainerWidth,
+    virtualizationBuffer,
+  } = args;
+
+  const chordCount = scrollPositions.length;
+  if (chordCount === 0) return { startIndex: 0, endIndex: 0 };
+
+  const positions = scrollPositions.map((position, index) =>
+    getChordPosition(index, scrollPositions, chordRepetitions, totalWidth),
+  );
+
+  const currentScrollPosition = positions[currentChordIndex] ?? 0;
+  const halfViewport = visiblePlaybackContainerWidth / 2;
+  const minVisiblePosition =
+    currentScrollPosition - halfViewport - virtualizationBuffer;
+  const maxVisiblePosition =
+    currentScrollPosition + halfViewport + virtualizationBuffer;
+
+  const rawStart = lowerBound(positions, minVisiblePosition, 0, chordCount - 1);
+  const rawEnd = upperBound(positions, maxVisiblePosition, 0, chordCount - 1);
+
+  return {
+    startIndex: Math.max(0, rawStart - 1),
+    endIndex: Math.min(chordCount - 1, rawEnd + 1),
+  };
+}
+
+function bruteForceVisibleRange(args) {
+  const {
+    scrollPositions,
+    chordRepetitions,
+    totalWidth,
+    currentChordIndex,
+    visiblePlaybackContainerWidth,
+    virtualizationBuffer,
+  } = args;
+  const chordCount = scrollPositions.length;
+  const currentScrollPosition =
+    (scrollPositions[currentChordIndex] ?? 0) +
+    (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
+
+  const halfViewport = visiblePlaybackContainerWidth / 2;
+  const minVisiblePosition =
+    currentScrollPosition - halfViewport - virtualizationBuffer;
+  const maxVisiblePosition =
+    currentScrollPosition + halfViewport + virtualizationBuffer;
+
+  let startIndex = 0;
+  let endIndex = chordCount - 1;
+
+  for (let i = 0; i < chordCount; i++) {
+    const chordPosition =
+      (scrollPositions[i] ?? 0) + (chordRepetitions[i] ?? 0) * totalWidth;
+    if (chordPosition >= minVisiblePosition) {
+      startIndex = Math.max(0, i - 1);
+      break;
+    }
+  }
+
+  for (let i = chordCount - 1; i >= 0; i--) {
+    const chordPosition =
+      (scrollPositions[i] ?? 0) + (chordRepetitions[i] ?? 0) * totalWidth;
+    if (chordPosition <= maxVisiblePosition) {
+      endIndex = Math.min(chordCount - 1, i + 1);
+      break;
+    }
+  }
+
+  return { startIndex, endIndex };
+}
+
+function buildScrollPositions(chordCount, chordWidth = 34) {
+  return Array.from({ length: chordCount }, (_, index) => index * chordWidth);
+}
+
+let passed = 0;
+let failed = 0;
+
+function assertEqual(label, actual, expected) {
+  if (
+    actual.startIndex === expected.startIndex &&
+    actual.endIndex === expected.endIndex
+  ) {
+    passed++;
+    return;
+  }
+  failed++;
+  console.error(`FAIL ${label}`, { actual, expected });
+}
+
+const chordCounts = [1, 8, 64, 200];
+const viewports = [320, 768, 1200];
+
+for (const chordCount of chordCounts) {
+  const scrollPositions = buildScrollPositions(chordCount);
+  const totalWidth = scrollPositions.at(-1) + 34;
+
+  for (const visiblePlaybackContainerWidth of viewports) {
+    for (let currentChordIndex = 0; currentChordIndex < chordCount; currentChordIndex++) {
+      for (const repetition of [0, 1, 3]) {
+        const chordRepetitions = new Array(chordCount).fill(repetition);
+        const args = {
+          scrollPositions,
+          chordRepetitions,
+          totalWidth,
+          currentChordIndex,
+          visiblePlaybackContainerWidth,
+          virtualizationBuffer: 100,
+        };
+
+        assertEqual(
+          `chords=${chordCount} idx=${currentChordIndex} rep=${repetition}`,
+          computePlaybackVisibleRange(args),
+          bruteForceVisibleRange(args),
+        );
+      }
+    }
+  }
+}
+
+console.log(`playbackVisibleRange: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/src/components/AudioControls/PlaybackProgressSlider.tsx
+++ b/src/components/AudioControls/PlaybackProgressSlider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, type Dispatch, type SetStateAction } from "react";
 import { getTrackBackground, Range } from "react-range";
 import { useTabStore } from "~/stores/TabStore";
+import { getPlaybackStutterDevFlags } from "~/utils/playbackStutterDevFlags";
 
 interface PlaybackProgressSlider {
   disabled: boolean;
@@ -134,6 +135,15 @@ function PlaybackProgressSlider({
   const isPlayingAndNotAtEnd =
     audioMetadata.playing &&
     (currentChordIndex + 1) % currentlyPlayingMetadata!.length !== 0;
+
+  const disableSliderTransitions =
+    process.env.NODE_ENV !== "production" &&
+    getPlaybackStutterDevFlags().disableSliderTransitions;
+
+  const sliderTransitionDuration =
+    audioMetadata.playing && !disableSliderTransitions
+      ? `${chordDurations[currentChordIndex] ?? 0}s`
+      : "0s";
 
   const maxIndex = currentlyPlayingMetadata
     ? currentlyPlayingMetadata.length - 1
@@ -277,11 +287,7 @@ function PlaybackProgressSlider({
                       })`,
                       transitionProperty: "transform",
                       transitionTimingFunction: "linear",
-                      transitionDuration: `${
-                        audioMetadata.playing
-                          ? `${chordDurations[currentChordIndex] ?? 0}s`
-                          : "0s"
-                      }`,
+                      transitionDuration: sliderTransitionDuration,
                     }}
                     className="absolute left-0 top-0 z-10 h-full w-full origin-left rounded-[4px] bg-primary will-change-transform"
                   ></div>
@@ -298,11 +304,7 @@ function PlaybackProgressSlider({
                 ...props.style,
                 transitionProperty: "transform",
                 transitionTimingFunction: "linear",
-                transitionDuration: `${
-                  audioMetadata.playing
-                    ? `${chordDurations[currentChordIndex] ?? 0}s`
-                    : "0s"
-                }`,
+                transitionDuration: sliderTransitionDuration,
               }}
               className="!z-20 size-[18px] rounded-full border border-foreground/50 bg-primary will-change-transform"
             />

--- a/src/components/Tab/Playback/PlaybackChordStrip.tsx
+++ b/src/components/Tab/Playback/PlaybackChordStrip.tsx
@@ -1,0 +1,516 @@
+import {
+  Profiler,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  type ProfilerOnRenderCallback,
+} from "react";
+import PlaybackStrummedChord from "~/components/Tab/Playback/PlaybackStrummedChord";
+import PlaybackTabChord from "~/components/Tab/Playback/PlaybackTabChord";
+import PlaybackTabMeasureLine from "~/components/Tab/Playback/PlaybackTabMeasureLine";
+import {
+  type PlaybackTabChord as PlaybackTabChordType,
+  type PlaybackStrummedChord as PlaybackStrummedChordType,
+  type PlaybackLoopDelaySpacerChord,
+  useTabStore,
+  type FullNoteLengths,
+} from "~/stores/TabStore";
+import {
+  getPlaybackStutterDevFlags,
+  shouldOmitInlineTransformWhilePlaying,
+} from "~/utils/playbackStutterDevFlags";
+import {
+  markPlaybackStutter,
+  measurePlaybackStutter,
+  startPlaybackStutterDiagnostics,
+} from "~/utils/playbackStutterDiagnostics";
+import { computePlaybackVisibleRange } from "~/utils/playbackVisibleRange";
+import usePlaybackStripAnimation from "~/hooks/usePlaybackStripAnimation";
+
+const VIRTUALIZATION_BUFFER = 100;
+
+interface ChordLayoutData {
+  scrollPositions: number[];
+  chordWidths: number[];
+  totalWidth: number;
+  durations: number[];
+  virtualizationIndex: number;
+  virtualizationStartIndex: number;
+  virtualizationCatchupIndex: number;
+}
+
+interface PlaybackChordStripProps {
+  scrollStripRef: React.RefObject<HTMLDivElement | null>;
+  initialPlaceholderWidth: number;
+  chordLayoutData: ChordLayoutData;
+  chordRepetitions: number[];
+  setChordRepetitions: React.Dispatch<React.SetStateAction<number[]>>;
+}
+
+const onProfilerRender: ProfilerOnRenderCallback = (
+  id,
+  phase,
+  actualDuration,
+) => {
+  if (actualDuration > 8) {
+    console.warn(
+      `[playback-stutter] React Profiler ${id} ${phase}: ${actualDuration.toFixed(1)}ms`,
+    );
+  }
+};
+
+function PlaybackChordStrip({
+  scrollStripRef,
+  initialPlaceholderWidth,
+  chordLayoutData,
+  chordRepetitions,
+  setChordRepetitions,
+}: PlaybackChordStripProps) {
+  const {
+    currentChordIndex,
+    expandedTabData,
+    visiblePlaybackContainerWidth,
+    audioMetadata,
+    audioContext,
+    playbackStartedAtAudioTime,
+    currentlyPlayingMetadata,
+    loopDelay,
+  } = useTabStore((state) => ({
+    currentChordIndex: state.currentChordIndex,
+    expandedTabData: state.expandedTabData,
+    visiblePlaybackContainerWidth: state.visiblePlaybackContainerWidth,
+    audioMetadata: state.audioMetadata,
+    audioContext: state.audioContext,
+    playbackStartedAtAudioTime: state.playbackStartedAtAudioTime,
+    currentlyPlayingMetadata: state.currentlyPlayingMetadata,
+    loopDelay: state.loopDelay,
+  }));
+
+  const devFlags = useMemo(() => getPlaybackStutterDevFlags(), []);
+  const disableHighlightTransitions = devFlags.disableHighlightTransitions;
+
+  useEffect(() => {
+    startPlaybackStutterDiagnostics();
+  }, []);
+
+  const currentChordRepetition = chordRepetitions[currentChordIndex] ?? 0;
+
+  usePlaybackStripAnimation({
+    stripRef: scrollStripRef,
+    chordLayoutData,
+    currentChordIndex,
+    currentRepetition: currentChordRepetition,
+    audioContext,
+    playbackStartedAtAudioTime,
+    playing: audioMetadata.playing,
+  });
+
+  const getChordScrollPosition = useCallback(
+    (index: number) => {
+      const { scrollPositions, totalWidth } = chordLayoutData;
+      return (
+        (scrollPositions[index] ?? 0) +
+        (chordRepetitions[index] ?? 0) * totalWidth
+      );
+    },
+    [chordLayoutData, chordRepetitions],
+  );
+
+  const visibleRange = useMemo(() => {
+    markPlaybackStutter("visible-range-compute:start");
+
+    if (
+      !expandedTabData ||
+      visiblePlaybackContainerWidth === 0 ||
+      chordRepetitions.length === 0
+    ) {
+      return { startIndex: 0, endIndex: 0 };
+    }
+
+    const result = devFlags.disableVirtualization
+      ? { startIndex: 0, endIndex: expandedTabData.length - 1 }
+      : computePlaybackVisibleRange({
+          scrollPositions: chordLayoutData.scrollPositions,
+          chordRepetitions,
+          totalWidth: chordLayoutData.totalWidth,
+          currentChordIndex,
+          visiblePlaybackContainerWidth,
+          virtualizationBuffer: VIRTUALIZATION_BUFFER,
+        });
+
+    measurePlaybackStutter("visible-range-compute", "visible-range-compute", {
+      startIndex: result.startIndex,
+      endIndex: result.endIndex,
+      chordCount: expandedTabData.length,
+    });
+
+    return result;
+  }, [
+    chordLayoutData,
+    chordRepetitions,
+    currentChordIndex,
+    devFlags.disableVirtualization,
+    expandedTabData,
+    visiblePlaybackContainerWidth,
+  ]);
+
+  useEffect(() => {
+    if (devFlags.freezeChordRepetitions) return;
+    if (
+      currentChordIndex < chordLayoutData.virtualizationIndex ||
+      chordRepetitions[0] !== chordRepetitions[chordRepetitions.length - 1]
+    ) {
+      return;
+    }
+
+    markPlaybackStutter("chord-repetitions-primary");
+    setChordRepetitions((prev) => {
+      const newRepetitions = (prev[0] ?? 0) + 1;
+      const oldRepetitions = prev[0] ?? 0;
+      const secondHalfLength =
+        prev.length - chordLayoutData.virtualizationStartIndex;
+
+      const firstNewHalf = new Array(
+        chordLayoutData.virtualizationStartIndex,
+      ).fill(newRepetitions) as number[];
+      const secondNewHalf = new Array(secondHalfLength).fill(
+        oldRepetitions,
+      ) as number[];
+
+      return [...firstNewHalf, ...secondNewHalf];
+    });
+  }, [
+    chordLayoutData,
+    chordRepetitions,
+    currentChordIndex,
+    devFlags.freezeChordRepetitions,
+    setChordRepetitions,
+  ]);
+
+  useEffect(() => {
+    if (devFlags.freezeChordRepetitions) return;
+    if (
+      currentChordIndex >= chordLayoutData.virtualizationIndex ||
+      currentChordIndex < chordLayoutData.virtualizationCatchupIndex ||
+      chordRepetitions[0] === chordRepetitions[chordRepetitions.length - 1]
+    ) {
+      return;
+    }
+
+    markPlaybackStutter("chord-repetitions-catchup");
+    setChordRepetitions((prev) => {
+      const newRepetitions = prev[0] ?? 0;
+      return new Array(prev.length).fill(newRepetitions) as number[];
+    });
+  }, [
+    chordLayoutData,
+    chordRepetitions,
+    currentChordIndex,
+    devFlags.freezeChordRepetitions,
+    setChordRepetitions,
+  ]);
+
+  const scrollContainerTransform = useMemo(() => {
+    const { scrollPositions, totalWidth } = chordLayoutData;
+    const position =
+      (scrollPositions[currentChordIndex] ?? 0) +
+      (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
+
+    return `translateX(${position * -1}px)`;
+  }, [chordLayoutData, chordRepetitions, currentChordIndex]);
+
+  const omitInlineTransform = shouldOmitInlineTransformWhilePlaying(
+    audioMetadata.playing,
+  );
+  const applyInlineTransform =
+    !audioMetadata.playing || !omitInlineTransform;
+
+  const isChordHighlighted = useCallback(
+    (chordIndex: number): boolean => {
+      if (
+        !expandedTabData ||
+        !currentlyPlayingMetadata ||
+        chordRepetitions.length === 0
+      ) {
+        return false;
+      }
+
+      if (currentChordIndex === chordIndex && audioMetadata.playing) {
+        return true;
+      }
+
+      const chordRep = chordRepetitions[chordIndex] ?? 0;
+      const currentRep = chordRepetitions[currentChordIndex] ?? 0;
+
+      if (chordRep < currentRep) return true;
+      if (chordRep === currentRep && chordIndex < currentChordIndex) return true;
+
+      return false;
+    },
+    [
+      audioMetadata.playing,
+      chordRepetitions,
+      currentChordIndex,
+      currentlyPlayingMetadata,
+      expandedTabData,
+    ],
+  );
+
+  const visibleChords = useMemo(() => {
+    if (!expandedTabData) return [];
+
+    const { startIndex, endIndex } = visibleRange;
+    const result: Array<{
+      chord:
+        | PlaybackTabChordType
+        | PlaybackStrummedChordType
+        | PlaybackLoopDelaySpacerChord;
+      index: number;
+      prevChord?:
+        | PlaybackTabChordType
+        | PlaybackStrummedChordType
+        | PlaybackLoopDelaySpacerChord;
+      nextChord?:
+        | PlaybackTabChordType
+        | PlaybackStrummedChordType
+        | PlaybackLoopDelaySpacerChord;
+    }> = [];
+
+    for (let i = startIndex; i <= endIndex; i++) {
+      const chord = expandedTabData[i];
+      if (chord) {
+        result.push({
+          chord,
+          index: i,
+          prevChord: expandedTabData[i - 1],
+          nextChord: expandedTabData[i + 1],
+        });
+      }
+    }
+
+    return result;
+  }, [expandedTabData, visibleRange]);
+
+  if (!expandedTabData) return null;
+
+  const strip = (
+    <div
+      ref={scrollStripRef}
+      style={{
+        width: `${chordLayoutData.totalWidth}px`,
+        ...(applyInlineTransform
+          ? {
+              transform: scrollContainerTransform,
+              transition: audioMetadata.playing
+                ? "none"
+                : "transform 0.2s linear",
+            }
+          : {}),
+      }}
+      className="relative flex items-center will-change-transform"
+    >
+      <div
+        style={{
+          position: "absolute",
+          zIndex: 2,
+          backgroundColor: "transparent",
+          left: 0,
+          width: `${initialPlaceholderWidth}px`,
+        }}
+      />
+      {visibleChords.map(({ chord, index, prevChord, nextChord }) => {
+        const isDimmed =
+          audioMetadata.editingLoopRange &&
+          (index < audioMetadata.startLoopIndex ||
+            (audioMetadata.endLoopIndex !== -1 &&
+              index > audioMetadata.endLoopIndex));
+
+        const isFirstChordInSection =
+          index === 0 &&
+          (loopDelay !== 0 || (chordRepetitions[0] ?? 0) === 0);
+
+        return (
+          <div
+            key={`${index}-${chordRepetitions[index] ?? 0}`}
+            style={{
+              position: "absolute",
+              width: `${chordLayoutData.chordWidths[index] ?? 0}px`,
+              left: `${
+                getChordScrollPosition(index) + initialPlaceholderWidth
+              }px`,
+            }}
+          >
+            <RenderChordByType
+              type={
+                chord.type === "strum"
+                  ? "strum"
+                  : chord.type === "tab"
+                    ? chord.data.chordData.includes("|")
+                      ? "measureLine"
+                      : "tab"
+                    : "loopDelaySpacer"
+              }
+              index={index}
+              prevChord={prevChord}
+              chord={chord}
+              nextChord={nextChord}
+              isFirstChordInSection={isFirstChordInSection}
+              isDimmed={isDimmed}
+              loopDelay={loopDelay}
+              isHighlighted={
+                !audioMetadata.editingLoopRange && isChordHighlighted(index)
+              }
+              disableHighlightTransitions={disableHighlightTransitions}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  if (devFlags.reactProfiler) {
+    return (
+      <Profiler id="PlaybackChordStrip" onRender={onProfilerRender}>
+        {strip}
+      </Profiler>
+    );
+  }
+
+  return strip;
+}
+
+interface RenderChordByTypeProps {
+  type: "tab" | "measureLine" | "strum" | "loopDelaySpacer";
+  index: number;
+  prevChord?:
+    | PlaybackTabChordType
+    | PlaybackStrummedChordType
+    | PlaybackLoopDelaySpacerChord;
+  chord:
+    | PlaybackTabChordType
+    | PlaybackStrummedChordType
+    | PlaybackLoopDelaySpacerChord;
+  nextChord?:
+    | PlaybackTabChordType
+    | PlaybackStrummedChordType
+    | PlaybackLoopDelaySpacerChord;
+  isFirstChordInSection: boolean;
+  isDimmed: boolean;
+  loopDelay: number;
+  isHighlighted: boolean;
+  disableHighlightTransitions?: boolean;
+}
+
+const RenderChordByType = memo(function RenderChordByType({
+  type,
+  index: _index,
+  prevChord,
+  chord,
+  nextChord,
+  isFirstChordInSection,
+  isDimmed,
+  loopDelay,
+  isHighlighted,
+  disableHighlightTransitions,
+}: RenderChordByTypeProps) {
+  const prevChordNoteLength = prevChord
+    ? prevChord.type === "strum" && !prevChord.isLastChord
+      ? prevChord.data.noteLength
+      : prevChord.type === "tab"
+        ? (prevChord.data.chordData[8] as FullNoteLengths)
+        : undefined
+    : undefined;
+
+  const currentChordNoteLength = chord
+    ? chord.type === "strum"
+      ? chord.data.noteLength
+      : chord.type === "tab"
+        ? (chord.data.chordData[8] as FullNoteLengths)
+        : undefined
+    : undefined;
+
+  const nextChordNoteLength = nextChord
+    ? nextChord.type === "strum" &&
+      (chord.type !== "strum" || !chord.isLastChord)
+      ? nextChord.data.noteLength
+      : nextChord.type === "tab"
+        ? (nextChord.data.chordData[8] as FullNoteLengths)
+        : undefined
+    : undefined;
+
+  const prevChordIsRest =
+    prevChord === undefined ||
+    (prevChord.type === "tab" && prevChord.data.chordData[7] === "r") ||
+    (prevChord.type === "strum" && prevChord.data.strum === "r");
+  const currentChordIsRest =
+    chord === undefined ||
+    (chord.type === "tab" && chord.data.chordData[7] === "r") ||
+    (chord.type === "strum" && chord.data.strum === "r");
+  const nextChordIsRest =
+    nextChord === undefined ||
+    (nextChord.type === "tab" && nextChord.data.chordData[7] === "r") ||
+    (nextChord.type === "strum" && nextChord.data.strum === "r");
+
+  if (type === "tab" && chord?.type === "tab") {
+    return (
+      <PlaybackTabChord
+        columnData={chord?.data.chordData}
+        isFirstChordInSection={isFirstChordInSection}
+        isLastChordInSection={chord?.isLastChord && loopDelay !== 0}
+        isHighlighted={isHighlighted}
+        isDimmed={isDimmed}
+        prevChordNoteLength={prevChordNoteLength}
+        currentChordNoteLength={currentChordNoteLength}
+        nextChordNoteLength={nextChordNoteLength}
+        prevChordIsRest={prevChordIsRest}
+        currentChordIsRest={currentChordIsRest}
+        nextChordIsRest={nextChordIsRest}
+        disableHighlightTransitions={disableHighlightTransitions}
+      />
+    );
+  }
+
+  if (type === "measureLine" && chord?.type === "tab") {
+    return (
+      <PlaybackTabMeasureLine
+        columnData={chord.data.chordData}
+        isDimmed={isDimmed}
+      />
+    );
+  }
+
+  if (type === "strum" && chord?.type === "strum") {
+    return (
+      <PlaybackStrummedChord
+        strumIndex={chord?.data.strumIndex || 0}
+        strum={chord?.data.strum || ""}
+        palmMute={chord?.data.palmMute || ""}
+        isFirstChordInSection={isFirstChordInSection}
+        isLastChordInSection={chord?.isLastChord && loopDelay !== 0}
+        noteLength={chord?.data.noteLength || "quarter"}
+        bpmToShow={chord?.data.showBpm ? chord?.data.bpm : undefined}
+        chordName={chord?.data.chordName || ""}
+        chordColor={chord?.data.chordColor || ""}
+        isHighlighted={isHighlighted}
+        beatIndicator={chord?.data.beatIndicator}
+        isDimmed={isDimmed}
+        prevChordNoteLength={prevChordNoteLength}
+        currentChordNoteLength={currentChordNoteLength}
+        nextChordNoteLength={nextChordNoteLength}
+        prevChordIsRest={prevChordIsRest}
+        currentChordIsRest={currentChordIsRest}
+        nextChordIsRest={nextChordIsRest}
+        disableHighlightTransitions={disableHighlightTransitions}
+      />
+    );
+  }
+
+  if (type === "loopDelaySpacer") {
+    return <div className="absolute left-0 h-full w-[34px]"></div>;
+  }
+
+  return null;
+});
+
+export default memo(PlaybackChordStrip);

--- a/src/components/Tab/Playback/PlaybackChordStrip.tsx
+++ b/src/components/Tab/Playback/PlaybackChordStrip.tsx
@@ -21,11 +21,9 @@ import {
   shouldOmitInlineTransformWhilePlaying,
 } from "~/utils/playbackStutterDevFlags";
 import {
-  markPlaybackStutter,
-  measurePlaybackStutter,
-  startPlaybackStutterDiagnostics,
-} from "~/utils/playbackStutterDiagnostics";
-import { computePlaybackVisibleRange } from "~/utils/playbackVisibleRange";
+  buildPlaybackChordPositions,
+  computePlaybackVisibleRange,
+} from "~/utils/playbackVisibleRange";
 import usePlaybackStripAnimation from "~/hooks/usePlaybackStripAnimation";
 
 const VIRTUALIZATION_BUFFER = 100;
@@ -67,32 +65,31 @@ function PlaybackChordStrip({
   chordRepetitions,
   setChordRepetitions,
 }: PlaybackChordStripProps) {
-  const {
-    currentChordIndex,
-    expandedTabData,
-    visiblePlaybackContainerWidth,
-    audioMetadata,
-    audioContext,
-    playbackStartedAtAudioTime,
-    currentlyPlayingMetadata,
-    loopDelay,
-  } = useTabStore((state) => ({
-    currentChordIndex: state.currentChordIndex,
-    expandedTabData: state.expandedTabData,
-    visiblePlaybackContainerWidth: state.visiblePlaybackContainerWidth,
-    audioMetadata: state.audioMetadata,
-    audioContext: state.audioContext,
-    playbackStartedAtAudioTime: state.playbackStartedAtAudioTime,
-    currentlyPlayingMetadata: state.currentlyPlayingMetadata,
-    loopDelay: state.loopDelay,
-  }));
+  const currentChordIndex = useTabStore((state) => state.currentChordIndex);
+  const expandedTabData = useTabStore((state) => state.expandedTabData);
+  const visiblePlaybackContainerWidth = useTabStore(
+    (state) => state.visiblePlaybackContainerWidth,
+  );
+  const audioMetadata = useTabStore((state) => state.audioMetadata);
+  const audioContext = useTabStore((state) => state.audioContext);
+  const playbackStartedAtAudioTime = useTabStore(
+    (state) => state.playbackStartedAtAudioTime,
+  );
+  const currentlyPlayingMetadata = useTabStore(
+    (state) => state.currentlyPlayingMetadata,
+  );
+  const loopDelay = useTabStore((state) => state.loopDelay);
+  const editingLoopRange = useTabStore(
+    (state) => state.audioMetadata.editingLoopRange,
+  );
+  const startLoopIndex = useTabStore(
+    (state) => state.audioMetadata.startLoopIndex,
+  );
+  const endLoopIndex = useTabStore((state) => state.audioMetadata.endLoopIndex);
+  const playing = useTabStore((state) => state.audioMetadata.playing);
 
   const devFlags = useMemo(() => getPlaybackStutterDevFlags(), []);
   const disableHighlightTransitions = devFlags.disableHighlightTransitions;
-
-  useEffect(() => {
-    startPlaybackStutterDiagnostics();
-  }, []);
 
   const currentChordRepetition = chordRepetitions[currentChordIndex] ?? 0;
 
@@ -103,23 +100,20 @@ function PlaybackChordStrip({
     currentRepetition: currentChordRepetition,
     audioContext,
     playbackStartedAtAudioTime,
-    playing: audioMetadata.playing,
+    playing,
   });
 
-  const getChordScrollPosition = useCallback(
-    (index: number) => {
-      const { scrollPositions, totalWidth } = chordLayoutData;
-      return (
-        (scrollPositions[index] ?? 0) +
-        (chordRepetitions[index] ?? 0) * totalWidth
-      );
-    },
-    [chordLayoutData, chordRepetitions],
+  const chordPositions = useMemo(
+    () =>
+      buildPlaybackChordPositions({
+        scrollPositions: chordLayoutData.scrollPositions,
+        chordRepetitions,
+        totalWidth: chordLayoutData.totalWidth,
+      }),
+    [chordLayoutData.scrollPositions, chordLayoutData.totalWidth, chordRepetitions],
   );
 
   const visibleRange = useMemo(() => {
-    markPlaybackStutter("visible-range-compute:start");
-
     if (
       !expandedTabData ||
       visiblePlaybackContainerWidth === 0 ||
@@ -128,26 +122,23 @@ function PlaybackChordStrip({
       return { startIndex: 0, endIndex: 0 };
     }
 
-    const result = devFlags.disableVirtualization
-      ? { startIndex: 0, endIndex: expandedTabData.length - 1 }
-      : computePlaybackVisibleRange({
-          scrollPositions: chordLayoutData.scrollPositions,
-          chordRepetitions,
-          totalWidth: chordLayoutData.totalWidth,
-          currentChordIndex,
-          visiblePlaybackContainerWidth,
-          virtualizationBuffer: VIRTUALIZATION_BUFFER,
-        });
+    if (devFlags.disableVirtualization) {
+      return { startIndex: 0, endIndex: expandedTabData.length - 1 };
+    }
 
-    measurePlaybackStutter("visible-range-compute", "visible-range-compute", {
-      startIndex: result.startIndex,
-      endIndex: result.endIndex,
-      chordCount: expandedTabData.length,
+    return computePlaybackVisibleRange({
+      scrollPositions: chordLayoutData.scrollPositions,
+      chordRepetitions,
+      totalWidth: chordLayoutData.totalWidth,
+      currentChordIndex,
+      visiblePlaybackContainerWidth,
+      virtualizationBuffer: VIRTUALIZATION_BUFFER,
+      chordPositions,
     });
-
-    return result;
   }, [
-    chordLayoutData,
+    chordLayoutData.scrollPositions,
+    chordLayoutData.totalWidth,
+    chordPositions,
     chordRepetitions,
     currentChordIndex,
     devFlags.disableVirtualization,
@@ -155,16 +146,18 @@ function PlaybackChordStrip({
     visiblePlaybackContainerWidth,
   ]);
 
+  const firstRepetition = chordRepetitions[0] ?? 0;
+  const lastRepetition = chordRepetitions[chordRepetitions.length - 1] ?? 0;
+  const repetitionsAreSynced = firstRepetition === lastRepetition;
+
+  // Only depend on currentChordIndex — guard before setState so we do not
+  // schedule updater work on every chord tick.
   useEffect(() => {
     if (devFlags.freezeChordRepetitions) return;
-    if (
-      currentChordIndex < chordLayoutData.virtualizationIndex ||
-      chordRepetitions[0] !== chordRepetitions[chordRepetitions.length - 1]
-    ) {
-      return;
-    }
+    if (chordRepetitions.length === 0) return;
+    if (currentChordIndex < chordLayoutData.virtualizationIndex) return;
+    if (!repetitionsAreSynced) return;
 
-    markPlaybackStutter("chord-repetitions-primary");
     setChordRepetitions((prev) => {
       const newRepetitions = (prev[0] ?? 0) + 1;
       const oldRepetitions = prev[0] ?? 0;
@@ -181,50 +174,43 @@ function PlaybackChordStrip({
       return [...firstNewHalf, ...secondNewHalf];
     });
   }, [
-    chordLayoutData,
-    chordRepetitions,
+    chordLayoutData.virtualizationIndex,
+    chordLayoutData.virtualizationStartIndex,
+    chordRepetitions.length,
     currentChordIndex,
     devFlags.freezeChordRepetitions,
+    repetitionsAreSynced,
     setChordRepetitions,
   ]);
 
   useEffect(() => {
     if (devFlags.freezeChordRepetitions) return;
-    if (
-      currentChordIndex >= chordLayoutData.virtualizationIndex ||
-      currentChordIndex < chordLayoutData.virtualizationCatchupIndex ||
-      chordRepetitions[0] === chordRepetitions[chordRepetitions.length - 1]
-    ) {
-      return;
-    }
+    if (chordRepetitions.length === 0) return;
+    if (currentChordIndex >= chordLayoutData.virtualizationIndex) return;
+    if (currentChordIndex < chordLayoutData.virtualizationCatchupIndex) return;
+    if (repetitionsAreSynced) return;
 
-    markPlaybackStutter("chord-repetitions-catchup");
     setChordRepetitions((prev) => {
       const newRepetitions = prev[0] ?? 0;
       return new Array(prev.length).fill(newRepetitions) as number[];
     });
   }, [
-    chordLayoutData,
-    chordRepetitions,
+    chordLayoutData.virtualizationCatchupIndex,
+    chordLayoutData.virtualizationIndex,
+    chordRepetitions.length,
     currentChordIndex,
     devFlags.freezeChordRepetitions,
+    repetitionsAreSynced,
     setChordRepetitions,
   ]);
 
   const scrollContainerTransform = useMemo(() => {
-    const { scrollPositions, totalWidth } = chordLayoutData;
-    const position =
-      (scrollPositions[currentChordIndex] ?? 0) +
-      (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
-
+    const position = chordPositions[currentChordIndex] ?? 0;
     return `translateX(${position * -1}px)`;
-  }, [chordLayoutData, chordRepetitions, currentChordIndex]);
+  }, [chordPositions, currentChordIndex]);
 
-  const omitInlineTransform = shouldOmitInlineTransformWhilePlaying(
-    audioMetadata.playing,
-  );
   const applyInlineTransform =
-    !audioMetadata.playing || !omitInlineTransform;
+    !playing || !shouldOmitInlineTransformWhilePlaying(playing);
 
   const isChordHighlighted = useCallback(
     (chordIndex: number): boolean => {
@@ -236,7 +222,7 @@ function PlaybackChordStrip({
         return false;
       }
 
-      if (currentChordIndex === chordIndex && audioMetadata.playing) {
+      if (currentChordIndex === chordIndex && playing) {
         return true;
       }
 
@@ -249,11 +235,11 @@ function PlaybackChordStrip({
       return false;
     },
     [
-      audioMetadata.playing,
       chordRepetitions,
       currentChordIndex,
       currentlyPlayingMetadata,
       expandedTabData,
+      playing,
     ],
   );
 
@@ -302,9 +288,7 @@ function PlaybackChordStrip({
         ...(applyInlineTransform
           ? {
               transform: scrollContainerTransform,
-              transition: audioMetadata.playing
-                ? "none"
-                : "transform 0.2s linear",
+              transition: playing ? "none" : "transform 0.2s linear",
             }
           : {}),
       }}
@@ -321,10 +305,9 @@ function PlaybackChordStrip({
       />
       {visibleChords.map(({ chord, index, prevChord, nextChord }) => {
         const isDimmed =
-          audioMetadata.editingLoopRange &&
-          (index < audioMetadata.startLoopIndex ||
-            (audioMetadata.endLoopIndex !== -1 &&
-              index > audioMetadata.endLoopIndex));
+          editingLoopRange &&
+          (index < startLoopIndex ||
+            (endLoopIndex !== -1 && index > endLoopIndex));
 
         const isFirstChordInSection =
           index === 0 &&
@@ -336,9 +319,7 @@ function PlaybackChordStrip({
             style={{
               position: "absolute",
               width: `${chordLayoutData.chordWidths[index] ?? 0}px`,
-              left: `${
-                getChordScrollPosition(index) + initialPlaceholderWidth
-              }px`,
+              left: `${(chordPositions[index] ?? 0) + initialPlaceholderWidth}px`,
             }}
           >
             <RenderChordByType
@@ -358,9 +339,7 @@ function PlaybackChordStrip({
               isFirstChordInSection={isFirstChordInSection}
               isDimmed={isDimmed}
               loopDelay={loopDelay}
-              isHighlighted={
-                !audioMetadata.editingLoopRange && isChordHighlighted(index)
-              }
+              isHighlighted={!editingLoopRange && isChordHighlighted(index)}
               disableHighlightTransitions={disableHighlightTransitions}
             />
           </div>

--- a/src/components/Tab/Playback/PlaybackModal.tsx
+++ b/src/components/Tab/Playback/PlaybackModal.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useRouter } from "next/router";
 import PlaybackAudioControls from "~/components/Tab/Playback/PlaybackAudio/PlaybackAudioControls";
 import PlaybackBottomMetadata from "~/components/Tab/Playback/PlaybackBottomMetadata";
 import PlaybackChordStrip from "~/components/Tab/Playback/PlaybackChordStrip";
@@ -14,7 +13,6 @@ import PlaybackScrollingContainer from "~/components/Tab/Playback/PlaybackScroll
 import { X } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import useModalScrollbarHandling from "~/hooks/useModalScrollbarHandling";
-import { getPlaybackStutterDevFlags } from "~/utils/playbackStutterDevFlags";
 
 const backdropVariants = {
   expanded: {
@@ -37,8 +35,6 @@ interface ChordLayoutData {
 }
 
 function PlaybackModal() {
-  const router = useRouter();
-
   const {
     currentChordIndex,
     expandedTabData,
@@ -108,12 +104,6 @@ function PlaybackModal() {
   }, [currentChordIndex, currentlyPlayingMetadata]);
 
   useModalScrollbarHandling(true);
-
-  useEffect(() => {
-    if (process.env.NODE_ENV !== "production") {
-      getPlaybackStutterDevFlags(router.query as Record<string, string>);
-    }
-  }, [router.query]);
 
   useEffect(() => {
     const html = document.documentElement;

--- a/src/components/Tab/Playback/PlaybackModal.tsx
+++ b/src/components/Tab/Playback/PlaybackModal.tsx
@@ -1,25 +1,20 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/router";
 import PlaybackAudioControls from "~/components/Tab/Playback/PlaybackAudio/PlaybackAudioControls";
 import PlaybackBottomMetadata from "~/components/Tab/Playback/PlaybackBottomMetadata";
-import PlaybackStrummedChord from "~/components/Tab/Playback/PlaybackStrummedChord";
-import PlaybackTabChord from "~/components/Tab/Playback/PlaybackTabChord";
-import PlaybackTabMeasureLine from "~/components/Tab/Playback/PlaybackTabMeasureLine";
+import PlaybackChordStrip from "~/components/Tab/Playback/PlaybackChordStrip";
 import PlaybackTopMetadata from "~/components/Tab/Playback/PlaybackTopMetadata";
 import { AnimatePresence, motion } from "framer-motion";
 import { FocusTrap } from "focus-trap-react";
 import {
-  type PlaybackTabChord as PlaybackTabChordType,
-  type PlaybackStrummedChord as PlaybackStrummedChordType,
-  type PlaybackLoopDelaySpacerChord,
   useTabStore,
-  type FullNoteLengths,
 } from "~/stores/TabStore";
 import PlaybackMenuContent from "~/components/Tab/Playback/PlaybackMenuContent";
 import PlaybackScrollingContainer from "~/components/Tab/Playback/PlaybackScrollingContainer";
 import { X } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import useModalScrollbarHandling from "~/hooks/useModalScrollbarHandling";
-import usePlaybackStripAnimation from "~/hooks/usePlaybackStripAnimation";
+import { getPlaybackStutterDevFlags } from "~/utils/playbackStutterDevFlags";
 
 const backdropVariants = {
   expanded: {
@@ -29,8 +24,6 @@ const backdropVariants = {
     opacity: 0,
   },
 };
-
-const VIRTUALIZATION_BUFFER = 100;
 
 interface ChordLayoutData {
   scrollPositions: number[];
@@ -44,22 +37,21 @@ interface ChordLayoutData {
 }
 
 function PlaybackModal() {
+  const router = useRouter();
+
   const {
     currentChordIndex,
     expandedTabData,
     playbackSpeed,
     playbackMetadata,
     audioMetadata,
-    audioContext,
     showPlaybackModal,
     setShowPlaybackModal,
     visiblePlaybackContainerWidth,
     setVisiblePlaybackContainerWidth,
     playbackModalViewingState,
     viewportLabel,
-    loopDelay,
     currentlyPlayingMetadata,
-    playbackStartedAtAudioTime,
     setAudioMetadata,
     setPlaybackModalViewingState,
     pauseAudio,
@@ -70,16 +62,13 @@ function PlaybackModal() {
     playbackSpeed: state.playbackSpeed,
     playbackMetadata: state.playbackMetadata,
     audioMetadata: state.audioMetadata,
-    audioContext: state.audioContext,
     showPlaybackModal: state.showPlaybackModal,
     setShowPlaybackModal: state.setShowPlaybackModal,
     visiblePlaybackContainerWidth: state.visiblePlaybackContainerWidth,
     setVisiblePlaybackContainerWidth: state.setVisiblePlaybackContainerWidth,
     playbackModalViewingState: state.playbackModalViewingState,
     viewportLabel: state.viewportLabel,
-    loopDelay: state.loopDelay,
     currentlyPlayingMetadata: state.currentlyPlayingMetadata,
-    playbackStartedAtAudioTime: state.playbackStartedAtAudioTime,
     setAudioMetadata: state.setAudioMetadata,
     setPlaybackModalViewingState: state.setPlaybackModalViewingState,
     pauseAudio: state.pauseAudio,
@@ -119,6 +108,12 @@ function PlaybackModal() {
   }, [currentChordIndex, currentlyPlayingMetadata]);
 
   useModalScrollbarHandling(true);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      getPlaybackStutterDevFlags(router.query as Record<string, string>);
+    }
+  }, [router.query]);
 
   useEffect(() => {
     const html = document.documentElement;
@@ -266,138 +261,6 @@ function PlaybackModal() {
     visiblePlaybackContainerWidth,
   ]);
 
-  // Helper to compute scroll position for a chord using chordRepetitions
-  const getChordScrollPosition = useCallback(
-    (index: number) => {
-      if (!chordLayoutData) return 0;
-      const { scrollPositions, totalWidth } = chordLayoutData;
-      return (
-        (scrollPositions[index] ?? 0) +
-        (chordRepetitions[index] ?? 0) * totalWidth
-      );
-    },
-    [chordLayoutData, chordRepetitions],
-  );
-
-  // Compute visible chord range using binary search with chordRepetitions
-  const visibleRange = useMemo<{
-    startIndex: number;
-    endIndex: number;
-  }>(() => {
-    if (
-      !chordLayoutData ||
-      !expandedTabData ||
-      !currentlyPlayingMetadata ||
-      visiblePlaybackContainerWidth === 0 ||
-      chordRepetitions.length === 0
-    ) {
-      return {
-        startIndex: 0,
-        endIndex: 0,
-      };
-    }
-
-    const { scrollPositions, totalWidth } = chordLayoutData;
-    const chordCount = expandedTabData.length;
-
-    // Get current chord's scroll position using its repetition count
-    const currentScrollPosition =
-      (scrollPositions[currentChordIndex] ?? 0) +
-      (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
-
-    const halfViewport = visiblePlaybackContainerWidth / 2;
-    const minVisiblePosition =
-      currentScrollPosition - halfViewport - VIRTUALIZATION_BUFFER;
-    const maxVisiblePosition =
-      currentScrollPosition + halfViewport + VIRTUALIZATION_BUFFER;
-
-    // Find visible range - we need to check each chord's actual position with its repetition
-    let startIndex = 0;
-    let endIndex = chordCount - 1;
-
-    // Find start index
-    for (let i = 0; i < chordCount; i++) {
-      const chordPosition =
-        (scrollPositions[i] ?? 0) + (chordRepetitions[i] ?? 0) * totalWidth;
-      if (chordPosition >= minVisiblePosition) {
-        startIndex = Math.max(0, i - 1);
-        break;
-      }
-    }
-
-    // Find end index
-    for (let i = chordCount - 1; i >= 0; i--) {
-      const chordPosition =
-        (scrollPositions[i] ?? 0) + (chordRepetitions[i] ?? 0) * totalWidth;
-      if (chordPosition <= maxVisiblePosition) {
-        endIndex = Math.min(chordCount - 1, i + 1);
-        break;
-      }
-    }
-
-    return {
-      startIndex,
-      endIndex,
-    };
-  }, [
-    chordLayoutData,
-    expandedTabData,
-    currentlyPlayingMetadata,
-    visiblePlaybackContainerWidth,
-    currentChordIndex,
-    chordRepetitions,
-  ]);
-
-  // Primary chord virtualization effect - increments all chords except the last visible portion
-  // Triggers when current chord index reaches the point where the last chord becomes visible
-  useEffect(() => {
-    if (
-      !chordLayoutData ||
-      chordRepetitions.length === 0 ||
-      currentChordIndex < chordLayoutData.virtualizationIndex ||
-      chordRepetitions[0] !== chordRepetitions[chordRepetitions.length - 1] // primary virtualization already happened
-    ) {
-      return;
-    }
-
-    setChordRepetitions((prev) => {
-      const newRepetitions = (prev[0] ?? 0) + 1;
-      const oldRepetitions = prev[0] ?? 0;
-      const secondHalfLength =
-        prev.length - chordLayoutData.virtualizationStartIndex;
-
-      const firstNewHalf = new Array(
-        chordLayoutData.virtualizationStartIndex,
-      ).fill(newRepetitions) as number[];
-      const secondNewHalf = new Array(secondHalfLength).fill(
-        oldRepetitions,
-      ) as number[];
-
-      return [...firstNewHalf, ...secondNewHalf];
-    });
-  }, [chordLayoutData, chordRepetitions, currentChordIndex]);
-
-  // Catchup chord virtualization effect - increments the remaining chords after they leave the viewport
-  // Triggers after the beginning of the tab leaves the viewport on a new loop
-  useEffect(() => {
-    if (
-      !chordLayoutData ||
-      chordRepetitions.length === 0 ||
-      // making sure that this only happens post-primary virtualization and not
-      // before the virtualizationCatchupIndex has been reached
-      currentChordIndex >= chordLayoutData.virtualizationIndex ||
-      currentChordIndex < chordLayoutData.virtualizationCatchupIndex ||
-      chordRepetitions[0] === chordRepetitions[chordRepetitions.length - 1] // all chords are already caught up
-    ) {
-      return;
-    }
-
-    setChordRepetitions((prev) => {
-      const newRepetitions = prev[0] ?? 0;
-      return new Array(prev.length).fill(newRepetitions) as number[];
-    });
-  }, [chordLayoutData, chordRepetitions, currentChordIndex]);
-
   // Handle resize
   useEffect(() => {
     function handleResize() {
@@ -431,117 +294,6 @@ function PlaybackModal() {
       setCurrentChordIndex(0);
     };
   }, [setPlaybackModalViewingState, setCurrentChordIndex]);
-
-  const currentChordRepetition = chordRepetitions[currentChordIndex] ?? 0;
-
-  usePlaybackStripAnimation({
-    stripRef: scrollStripRef,
-    chordLayoutData,
-    currentChordIndex,
-    currentRepetition: currentChordRepetition,
-    audioContext,
-    playbackStartedAtAudioTime,
-    playing: audioMetadata.playing,
-  });
-
-  // Keep the inline transform at the current chord boundary.
-  // While playing, WAAPI owns motion; while paused, this preserves the existing settle/scrub path.
-  const scrollContainerTransform = useMemo(() => {
-    if (
-      !chordLayoutData ||
-      !expandedTabData ||
-      !currentlyPlayingMetadata ||
-      chordRepetitions.length === 0
-    )
-      return "translateX(0px)";
-
-    const { scrollPositions, totalWidth } = chordLayoutData;
-    const position =
-      (scrollPositions[currentChordIndex] ?? 0) +
-      (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
-
-    return `translateX(${position * -1}px)`;
-  }, [
-    chordLayoutData,
-    expandedTabData,
-    currentlyPlayingMetadata,
-    currentChordIndex,
-    chordRepetitions,
-  ]);
-
-  const isChordHighlighted = useCallback(
-    (chordIndex: number): boolean => {
-      if (
-        !expandedTabData ||
-        !currentlyPlayingMetadata ||
-        chordRepetitions.length === 0
-      )
-        return false;
-
-      if (currentChordIndex === chordIndex && audioMetadata.playing) {
-        return true;
-      }
-
-      // A chord is highlighted if:
-      // 1. It has the same repetition count as the current chord AND comes before it
-      // 2. OR it has a lower repetition count (from the previous loop but still visible)
-      const chordRep = chordRepetitions[chordIndex] ?? 0;
-      const currentRep = chordRepetitions[currentChordIndex] ?? 0;
-
-      if (chordRep < currentRep) {
-        return true;
-      }
-
-      if (chordRep === currentRep && chordIndex < currentChordIndex) {
-        return true;
-      }
-
-      return false;
-    },
-    [
-      expandedTabData,
-      currentlyPlayingMetadata,
-      currentChordIndex,
-      chordRepetitions,
-      audioMetadata.playing,
-    ],
-  );
-
-  // Get visible chords - uses chordRepetitions for positioning
-  const visibleChords = useMemo(() => {
-    if (!expandedTabData || !chordLayoutData) return [];
-
-    const { startIndex, endIndex } = visibleRange;
-    const result: Array<{
-      chord:
-        | PlaybackTabChordType
-        | PlaybackStrummedChordType
-        | PlaybackLoopDelaySpacerChord;
-      index: number;
-      prevChord?:
-        | PlaybackTabChordType
-        | PlaybackStrummedChordType
-        | PlaybackLoopDelaySpacerChord;
-      nextChord?:
-        | PlaybackTabChordType
-        | PlaybackStrummedChordType
-        | PlaybackLoopDelaySpacerChord;
-    }> = [];
-
-    for (let i = startIndex; i <= endIndex; i++) {
-      const chord = expandedTabData[i];
-      if (chord) {
-        result.push({
-          chord,
-          index: i,
-          prevChord: expandedTabData[i - 1],
-          nextChord: expandedTabData[i + 1],
-        });
-      }
-    }
-
-    return result;
-  }, [expandedTabData, chordLayoutData, visibleRange]);
 
   return (
     <motion.div
@@ -630,82 +382,13 @@ function PlaybackModal() {
                       </div>
 
                       {chordLayoutData && expandedTabData && (
-                        <div
-                          ref={scrollStripRef}
-                          style={{
-                            width: `${chordLayoutData.totalWidth}px`,
-                            transform: scrollContainerTransform,
-                            transition: audioMetadata.playing
-                              ? "none"
-                              : "transform 0.2s linear",
-                          }}
-                          className="relative flex items-center will-change-transform"
-                        >
-                          <div
-                            style={{
-                              position: "absolute",
-                              zIndex: 2,
-                              backgroundColor: "transparent",
-                              left: 0,
-                              width: `${initialPlaceholderWidth}px`,
-                            }}
-                          ></div>
-
-                          {/* Only render visible chords - true virtualization with chordRepetitions for smooth looping */}
-                          {visibleChords.map(
-                            ({ chord, index, prevChord, nextChord }) => {
-                              const isDimmed =
-                                audioMetadata.editingLoopRange &&
-                                (index < audioMetadata.startLoopIndex ||
-                                  (audioMetadata.endLoopIndex !== -1 &&
-                                    index > audioMetadata.endLoopIndex));
-
-                              const isFirstChordInSection =
-                                index === 0 &&
-                                (loopDelay !== 0 ||
-                                  (chordRepetitions[0] ?? 0) === 0);
-
-                              return (
-                                <div
-                                  key={`${index}-${chordRepetitions[index] ?? 0}`}
-                                  style={{
-                                    position: "absolute",
-                                    width: `${chordLayoutData.chordWidths[index] ?? 0}px`,
-                                    left: `${
-                                      getChordScrollPosition(index) +
-                                      initialPlaceholderWidth
-                                    }px`,
-                                  }}
-                                >
-                                  <RenderChordByType
-                                    type={
-                                      chord.type === "strum"
-                                        ? "strum"
-                                        : chord.type === "tab"
-                                          ? chord.data.chordData.includes("|")
-                                            ? "measureLine"
-                                            : "tab"
-                                          : "loopDelaySpacer"
-                                    }
-                                    index={index}
-                                    prevChord={prevChord}
-                                    chord={chord}
-                                    nextChord={nextChord}
-                                    isFirstChordInSection={
-                                      isFirstChordInSection
-                                    }
-                                    isDimmed={isDimmed}
-                                    loopDelay={loopDelay}
-                                    isHighlighted={
-                                      !audioMetadata.editingLoopRange &&
-                                      isChordHighlighted(index)
-                                    }
-                                  />
-                                </div>
-                              );
-                            },
-                          )}
-                        </div>
+                        <PlaybackChordStrip
+                          scrollStripRef={scrollStripRef}
+                          initialPlaceholderWidth={initialPlaceholderWidth}
+                          chordLayoutData={chordLayoutData}
+                          chordRepetitions={chordRepetitions}
+                          setChordRepetitions={setChordRepetitions}
+                        />
                       )}
                     </div>
                   </PlaybackScrollingContainer>
@@ -766,130 +449,3 @@ function PlaybackModal() {
 }
 
 export default PlaybackModal;
-
-interface RenderChordByTypeProps {
-  type: "tab" | "measureLine" | "strum" | "loopDelaySpacer";
-  index: number;
-  prevChord?:
-    | PlaybackTabChordType
-    | PlaybackStrummedChordType
-    | PlaybackLoopDelaySpacerChord;
-  chord:
-    | PlaybackTabChordType
-    | PlaybackStrummedChordType
-    | PlaybackLoopDelaySpacerChord;
-  nextChord?:
-    | PlaybackTabChordType
-    | PlaybackStrummedChordType
-    | PlaybackLoopDelaySpacerChord;
-  isFirstChordInSection: boolean;
-  isDimmed: boolean;
-  loopDelay: number;
-  isHighlighted: boolean;
-}
-
-const RenderChordByType = memo(function RenderChordByType({
-  type,
-  index: _index,
-  prevChord,
-  chord,
-  nextChord,
-  isFirstChordInSection,
-  isDimmed,
-  loopDelay,
-  isHighlighted,
-}: RenderChordByTypeProps) {
-  const prevChordNoteLength = prevChord
-    ? prevChord.type === "strum" && !prevChord.isLastChord // don't want to have separate strumming patterns' note length guides be connected
-      ? prevChord.data.noteLength
-      : prevChord.type === "tab"
-        ? (prevChord.data.chordData[8] as FullNoteLengths)
-        : undefined
-    : undefined;
-
-  const currentChordNoteLength = chord
-    ? chord.type === "strum"
-      ? chord.data.noteLength
-      : chord.type === "tab"
-        ? (chord.data.chordData[8] as FullNoteLengths)
-        : undefined
-    : undefined;
-
-  const nextChordNoteLength = nextChord
-    ? nextChord.type === "strum" &&
-      (chord.type !== "strum" || !chord.isLastChord) // don't want to have separate strumming patterns' note length guides be connected
-      ? nextChord.data.noteLength
-      : nextChord.type === "tab"
-        ? (nextChord.data.chordData[8] as FullNoteLengths)
-        : undefined
-    : undefined;
-
-  const prevChordIsRest =
-    prevChord === undefined ||
-    (prevChord.type === "tab" && prevChord.data.chordData[7] === "r") ||
-    (prevChord.type === "strum" && prevChord.data.strum === "r");
-  const currentChordIsRest =
-    chord === undefined ||
-    (chord.type === "tab" && chord.data.chordData[7] === "r") ||
-    (chord.type === "strum" && chord.data.strum === "r");
-  const nextChordIsRest =
-    nextChord === undefined ||
-    (nextChord.type === "tab" && nextChord.data.chordData[7] === "r") ||
-    (nextChord.type === "strum" && nextChord.data.strum === "r");
-
-  if (type === "tab" && chord?.type === "tab") {
-    return (
-      <PlaybackTabChord
-        columnData={chord?.data.chordData}
-        isFirstChordInSection={isFirstChordInSection}
-        isLastChordInSection={chord?.isLastChord && loopDelay !== 0}
-        isHighlighted={isHighlighted}
-        isDimmed={isDimmed}
-        prevChordNoteLength={prevChordNoteLength}
-        currentChordNoteLength={currentChordNoteLength}
-        nextChordNoteLength={nextChordNoteLength}
-        prevChordIsRest={prevChordIsRest}
-        currentChordIsRest={currentChordIsRest}
-        nextChordIsRest={nextChordIsRest}
-      />
-    );
-  }
-
-  if (type === "measureLine" && chord?.type === "tab") {
-    return (
-      <PlaybackTabMeasureLine
-        columnData={chord.data.chordData}
-        isDimmed={isDimmed}
-      />
-    );
-  }
-
-  if (type === "strum" && chord?.type === "strum") {
-    return (
-      <PlaybackStrummedChord
-        strumIndex={chord?.data.strumIndex || 0}
-        strum={chord?.data.strum || ""}
-        palmMute={chord?.data.palmMute || ""}
-        isFirstChordInSection={isFirstChordInSection}
-        isLastChordInSection={chord?.isLastChord && loopDelay !== 0}
-        noteLength={chord?.data.noteLength || "quarter"}
-        bpmToShow={chord?.data.showBpm ? chord?.data.bpm : undefined}
-        chordName={chord?.data.chordName || ""}
-        chordColor={chord?.data.chordColor || ""}
-        isHighlighted={isHighlighted}
-        beatIndicator={chord?.data.beatIndicator}
-        isDimmed={isDimmed}
-        prevChordNoteLength={prevChordNoteLength}
-        currentChordNoteLength={currentChordNoteLength}
-        nextChordNoteLength={nextChordNoteLength}
-        prevChordIsRest={prevChordIsRest}
-        currentChordIsRest={currentChordIsRest}
-        nextChordIsRest={nextChordIsRest}
-      />
-    );
-  }
-
-  if (type === "loopDelaySpacer") {
-    return <div className="absolute left-0 h-full w-[34px]"></div>;
-  }
-});

--- a/src/components/Tab/Playback/PlaybackStrummedChord.tsx
+++ b/src/components/Tab/Playback/PlaybackStrummedChord.tsx
@@ -27,6 +27,7 @@ interface PlaybackStrummedChord {
   prevChordIsRest: boolean;
   currentChordIsRest: boolean;
   nextChordIsRest: boolean;
+  disableHighlightTransitions?: boolean;
 }
 
 function PlaybackStrummedChord({
@@ -48,6 +49,7 @@ function PlaybackStrummedChord({
   prevChordIsRest,
   currentChordIsRest,
   nextChordIsRest,
+  disableHighlightTransitions,
 }: PlaybackStrummedChord) {
   const { chordDisplayMode } = useTabStore((state) => ({
     chordDisplayMode: state.chordDisplayMode,
@@ -132,7 +134,7 @@ function PlaybackStrummedChord({
                       ? "hsl(var(--primary))"
                       : "hsl(var(--foreground))",
               }}
-              className="baseVertFlex relative mb-2 h-[20px] text-lg transition-colors"
+              className={`baseVertFlex relative mb-2 h-[20px] text-lg ${disableHighlightTransitions ? "" : "transition-colors"}`}
             >
               <div className="baseFlex">
                 {strum.includes("v") && (

--- a/src/components/Tab/Playback/PlaybackTabChord.tsx
+++ b/src/components/Tab/Playback/PlaybackTabChord.tsx
@@ -18,6 +18,7 @@ interface PlaybackTabChord {
   prevChordIsRest: boolean;
   currentChordIsRest: boolean;
   nextChordIsRest: boolean;
+  disableHighlightTransitions?: boolean;
 }
 
 function PlaybackTabChord({
@@ -32,6 +33,7 @@ function PlaybackTabChord({
   prevChordIsRest,
   currentChordIsRest,
   nextChordIsRest,
+  disableHighlightTransitions,
 }: PlaybackTabChord) {
   const chordEffect = columnData[7] || "";
 
@@ -117,6 +119,7 @@ function PlaybackTabChord({
                             : note
                       }
                       isHighlighted={isHighlighted}
+                      disableHighlightTransitions={disableHighlightTransitions}
                       isAccented={
                         note.includes(">") || columnData[7]?.includes(">")
                       }
@@ -220,6 +223,7 @@ interface PlaybackTabNote {
   isAccented?: boolean;
   isStaccato?: boolean;
   isRest?: boolean;
+  disableHighlightTransitions?: boolean;
 }
 
 const PlaybackTabNote = memo(function PlaybackTabNote({
@@ -228,6 +232,7 @@ const PlaybackTabNote = memo(function PlaybackTabNote({
   isAccented,
   isStaccato,
   isRest,
+  disableHighlightTransitions,
 }: PlaybackTabNote) {
   return (
     <div className="baseFlex w-[34px]">
@@ -237,7 +242,7 @@ const PlaybackTabNote = memo(function PlaybackTabNote({
           color: isHighlighted
             ? "hsl(var(--primary))"
             : "hsl(var(--foreground))",
-          transitionDuration: "75ms",
+          transitionDuration: disableHighlightTransitions ? "0ms" : "75ms",
 
           // "x" wasn't as centered as regular numbers were, manual adjustment below
           marginTop: note === "x" ? "-2px" : "0",

--- a/src/hooks/usePlaybackStripAnimation.ts
+++ b/src/hooks/usePlaybackStripAnimation.ts
@@ -5,6 +5,7 @@ import {
   useRef,
   type RefObject,
 } from "react";
+import { markPlaybackStutter } from "~/utils/playbackStutterDiagnostics";
 
 interface PlaybackStripLayoutData {
   scrollPositions: number[];
@@ -145,6 +146,7 @@ function usePlaybackStripAnimation({
   useLayoutEffect(() => {
     const currentAnimation = animationRef.current;
     if (currentAnimation) {
+      markPlaybackStutter("waapi-cancel");
       currentAnimation.onfinish = null;
       currentAnimation.cancel();
       animationRef.current = null;
@@ -222,6 +224,10 @@ function usePlaybackStripAnimation({
 
       animation.play();
       animationRef.current = animation;
+      markPlaybackStutter("waapi-start", {
+        startTimeMs,
+        repetitionBase: repetitionBaseRef.current,
+      });
     };
 
     startAnimation(initialCurrentTimeMs);

--- a/src/pages/dev-playback-stutter-harness.tsx
+++ b/src/pages/dev-playback-stutter-harness.tsx
@@ -1,0 +1,245 @@
+// Dev-only harness for playback modal stutter diagnostics and A/B flags.
+import ErrorPage from "next/error";
+import { useRouter } from "next/router";
+import { useEffect, useMemo } from "react";
+import PlaybackModal from "~/components/Tab/Playback/PlaybackModal";
+import { useTabStore } from "~/stores/TabStore";
+import { expandFullTab } from "~/utils/playbackChordCompilationHelpers";
+import { generateDefaultSectionProgression } from "~/utils/chordCompilationHelpers";
+import { getPlaybackStutterDevFlags } from "~/utils/playbackStutterDevFlags";
+import { startPlaybackStutterDiagnostics } from "~/utils/playbackStutterDiagnostics";
+
+function note(id: string) {
+  return {
+    type: "note" as const,
+    palmMute: "",
+    firstString: "",
+    secondString: "3",
+    thirdString: "2",
+    fourthString: "0",
+    fifthString: "",
+    sixthString: "",
+    chordEffects: "",
+    noteLength: "quarter" as const,
+    id,
+  };
+}
+
+function measureLine(id: string) {
+  return {
+    type: "measureLine" as const,
+    isInPalmMuteSection: false,
+    bpmAfterLine: null,
+    id,
+  };
+}
+
+function makeColumns(prefix: string, measures: number) {
+  const columns: ReturnType<typeof note>[] = [];
+  for (let m = 0; m < measures; m++) {
+    for (let n = 0; n < 8; n++) {
+      columns.push(note(`${prefix}-n-${m}-${n}`));
+    }
+    if (m < measures - 1) {
+      columns.push(measureLine(`${prefix}-ml-${m}`));
+    }
+  }
+  return columns;
+}
+
+function makeTabSection(id: string, measures: number) {
+  return {
+    id,
+    type: "tab" as const,
+    bpm: 120,
+    baseNoteLength: "quarter" as const,
+    repetitions: 1,
+    data: makeColumns(id, measures),
+  };
+}
+
+function buildFixture(fixture: string) {
+  if (fixture === "huge") {
+    return [
+      {
+        id: "huge-section",
+        title: "Huge section",
+        data: [makeTabSection("huge-sub", 32)],
+      },
+    ];
+  }
+
+  return Array.from({ length: 4 }, (_, sectionIndex) => ({
+    id: `section-${sectionIndex}`,
+    title: `Section ${sectionIndex + 1}`,
+    data: [
+      makeTabSection(`sub-${sectionIndex}-0`, 8),
+      makeTabSection(`sub-${sectionIndex}-1`, 8),
+    ],
+  }));
+}
+
+const DEV_FLAG_DOCS = [
+  {
+    param: "playbackStutterDebug=1",
+    description: "Performance marks, long-task observer, console summaries",
+  },
+  {
+    param: "playbackReactProfiler=1",
+    description: "React.Profiler around PlaybackChordStrip",
+  },
+  {
+    param: "playbackSkipInlineTransform=0",
+    description: "Restore inline transform during play (pre-fix behavior)",
+  },
+  {
+    param: "playbackDisableVirtualization=1",
+    description: "Render every chord instead of visible window",
+  },
+  {
+    param: "playbackFreezeRepetitions=1",
+    description: "Skip chordRepetitions batch updates at loop",
+  },
+  {
+    param: "playbackDisableHighlights=1",
+    description: "Disable 75ms highlight color transitions",
+  },
+  {
+    param: "playbackDisableSliderTransitions=1",
+    description: "Disable progress slider CSS transitions while playing",
+  },
+  {
+    param: "playbackSkipLoopSliderReset=1",
+    description: "Skip slider reset + forced reflow at loop boundary",
+  },
+];
+
+export default function DevPlaybackStutterHarnessPage() {
+  const router = useRouter();
+  const fixture =
+    typeof router.query.fixture === "string" ? router.query.fixture : "realistic";
+  const tabData = useMemo(() => buildFixture(fixture), [fixture]);
+
+  const {
+    setShowPlaybackModal,
+    showPlaybackModal,
+    setId,
+    setTabData,
+    setExpandedTabData,
+    setPlaybackMetadata,
+    setCurrentlyPlayingMetadata,
+    setVisiblePlaybackContainerWidth,
+    chords,
+    bpm,
+    storeTabData,
+  } = useTabStore((state) => ({
+    setShowPlaybackModal: state.setShowPlaybackModal,
+    showPlaybackModal: state.showPlaybackModal,
+    setId: state.setId,
+    setTabData: state.setTabData,
+    setExpandedTabData: state.setExpandedTabData,
+    setPlaybackMetadata: state.setPlaybackMetadata,
+    setCurrentlyPlayingMetadata: state.setCurrentlyPlayingMetadata,
+    setVisiblePlaybackContainerWidth: state.setVisiblePlaybackContainerWidth,
+    chords: state.chords,
+    bpm: state.bpm,
+    storeTabData: state.tabData,
+  }));
+
+  const ready = storeTabData[0]?.id === tabData[0]?.id;
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production" || !router.isReady) return;
+
+    getPlaybackStutterDevFlags(router.query as Record<string, string>);
+    startPlaybackStutterDiagnostics();
+
+    setId(1);
+    setTabData((draft) => {
+      draft.splice(0, draft.length, ...tabData);
+    });
+    setVisiblePlaybackContainerWidth(1024);
+
+    const sectionProgression = generateDefaultSectionProgression(tabData);
+    const expanded = expandFullTab({
+      tabData,
+      location: null,
+      sectionProgression,
+      chords,
+      baselineBpm: bpm,
+      playbackSpeed: 1,
+      setPlaybackMetadata,
+      startLoopIndex: 0,
+      endLoopIndex: -1,
+      loopDelay: 0,
+      visiblePlaybackContainerWidth: 1024,
+    });
+
+    setExpandedTabData(expanded.chords);
+    setCurrentlyPlayingMetadata(expanded.chords.length);
+    setShowPlaybackModal(true);
+
+    return () => {
+      setShowPlaybackModal(false);
+    };
+  }, [
+    router.isReady,
+    router.query,
+    tabData,
+    setId,
+    setTabData,
+    setExpandedTabData,
+    setPlaybackMetadata,
+    setCurrentlyPlayingMetadata,
+    setVisiblePlaybackContainerWidth,
+    setShowPlaybackModal,
+    chords,
+    bpm,
+  ]);
+
+  if (process.env.NODE_ENV === "production") {
+    return <ErrorPage statusCode={404} />;
+  }
+
+  const activeFlags = getPlaybackStutterDevFlags();
+
+  return (
+    <div
+      id="devPlaybackStutterHarness"
+      data-ready={ready}
+      className="min-h-dvh bg-background p-4 text-sm text-foreground"
+    >
+      <h1 className="mb-2 text-lg font-semibold">
+        Playback stutter diagnostics harness
+      </h1>
+      <p className="mb-4 max-w-3xl text-muted-foreground">
+        Fixture: <code>{fixture}</code>. Open Chrome Performance while playing.
+        Console: <code>__playbackStutterDiagnostics.summarize()</code>
+      </p>
+
+      <div className="mb-4 grid max-w-3xl gap-2 rounded-md border border-border p-3">
+        <p className="font-medium">Active dev flags</p>
+        <ul className="list-inside list-disc text-muted-foreground">
+          {Object.entries(activeFlags).map(([key, value]) => (
+            <li key={key}>
+              {key}: <code>{String(value)}</code>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mb-6 grid max-w-3xl gap-2 rounded-md border border-border p-3">
+        <p className="font-medium">Query params</p>
+        <ul className="list-inside list-disc text-muted-foreground">
+          {DEV_FLAG_DOCS.map(({ param, description }) => (
+            <li key={param}>
+              <code>{param}</code> — {description}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {ready && showPlaybackModal && <PlaybackModal />}
+    </div>
+  );
+}

--- a/src/stores/TabStore.ts
+++ b/src/stores/TabStore.ts
@@ -1028,17 +1028,10 @@ const useTabStoreBase = create<TabState>()(
               chordIndex,
             });
 
-            // In the playback modal, WAAPI onfinish chains the strip loop on the
-            // compositor. Avoid resetting playbackStartedAtAudioTime here so the
-            // hook does not cancel and restart the animation at every loop seam.
-            if (showPlaybackModal) {
-              set({ currentChordIndex: 0 });
-            } else {
-              set({
-                currentChordIndex: 0,
-                playbackStartedAtAudioTime: nextChordStartTime,
-              });
-            }
+            set({
+              currentChordIndex: 0,
+              playbackStartedAtAudioTime: nextChordStartTime,
+            });
 
             // Reset chordIndex to -1 so that after the loop's increment, it becomes 0
             chordIndex = -1;

--- a/src/stores/TabStore.ts
+++ b/src/stores/TabStore.ts
@@ -13,6 +13,10 @@ import {
 import { resetProgressTabSliderPosition } from "~/utils/tabSliderHelpers";
 import { DEFAULT_TUNING, normalizeTuningValue, parse } from "~/utils/tunings";
 import { expandFullTab } from "~/utils/playbackChordCompilationHelpers";
+import {
+  recordChordIndexSet,
+  recordLoopBoundary,
+} from "~/utils/playbackStutterDiagnostics";
 import { useShallow } from "zustand/shallow";
 
 export interface SectionProgression {
@@ -949,6 +953,7 @@ const useTabStoreBase = create<TabState>()(
             set({
               currentChordIndex: chordIndex,
             });
+            recordChordIndexSet(chordIndex, true);
 
             const thirdPrevColumn = compiledChords[adjustedChordIndex - 3];
             const secondPrevColumn = compiledChords[adjustedChordIndex - 2];
@@ -1018,11 +1023,22 @@ const useTabStoreBase = create<TabState>()(
             nextChordStartTime =
               audioContext.currentTime + playbackStartEpsilonSeconds;
 
-            // Reset the current chord index to 0 to start over
-            set({
-              currentChordIndex: 0,
-              playbackStartedAtAudioTime: nextChordStartTime,
+            recordLoopBoundary({
+              showPlaybackModal: showPlaybackModal ? 1 : 0,
+              chordIndex,
             });
+
+            // In the playback modal, WAAPI onfinish chains the strip loop on the
+            // compositor. Avoid resetting playbackStartedAtAudioTime here so the
+            // hook does not cancel and restart the animation at every loop seam.
+            if (showPlaybackModal) {
+              set({ currentChordIndex: 0 });
+            } else {
+              set({
+                currentChordIndex: 0,
+                playbackStartedAtAudioTime: nextChordStartTime,
+              });
+            }
 
             // Reset chordIndex to -1 so that after the loop's increment, it becomes 0
             chordIndex = -1;

--- a/src/types/playbackStutterDiagnostics.d.ts
+++ b/src/types/playbackStutterDiagnostics.d.ts
@@ -1,0 +1,13 @@
+import type { summarizePlaybackStutterDiagnostics } from "~/utils/playbackStutterDiagnostics";
+
+declare global {
+  interface Window {
+    __playbackStutterDiagnostics?: {
+      getRecentSamples: () => unknown[];
+      summarize: typeof summarizePlaybackStutterDiagnostics;
+      clear: () => void;
+    };
+  }
+}
+
+export {};

--- a/src/utils/playbackStutterDevFlags.ts
+++ b/src/utils/playbackStutterDevFlags.ts
@@ -1,0 +1,157 @@
+// Dev-only flags for bisecting playback modal stutter causes.
+// Enable via URL query params on any page, e.g.:
+//   ?playbackStutterDebug=1
+//   ?playbackStutterDebug=1&playbackSkipInlineTransform=1
+// Flags persist in sessionStorage for the tab session.
+
+const SESSION_PREFIX = "playbackStutter:";
+
+export interface PlaybackStutterDevFlags {
+  /** Master switch: performance marks, long-task observer, console summaries */
+  debug: boolean;
+  /** Wrap PlaybackModal strip in React.Profiler */
+  reactProfiler: boolean;
+  /** Omit inline transform on the strip while playing (production fix A/B) */
+  skipInlineTransformWhilePlaying: boolean;
+  /** Render every chord instead of visibleRange windowing */
+  disableVirtualization: boolean;
+  /** Skip chordRepetitions batch updates during loop */
+  freezeChordRepetitions: boolean;
+  /** Pass disableHighlightTransitions to chord components */
+  disableHighlightTransitions: boolean;
+  /** Zero out progress slider CSS transitions while playing */
+  disableSliderTransitions: boolean;
+  /** Skip resetProgressTabSliderPosition at loop boundary */
+  skipLoopSliderReset: boolean;
+}
+
+const DEFAULT_FLAGS: PlaybackStutterDevFlags = {
+  debug: false,
+  reactProfiler: false,
+  skipInlineTransformWhilePlaying: true,
+  disableVirtualization: false,
+  freezeChordRepetitions: false,
+  disableHighlightTransitions: false,
+  disableSliderTransitions: false,
+  skipLoopSliderReset: false,
+};
+
+const FLAG_KEYS: (keyof PlaybackStutterDevFlags)[] = [
+  "debug",
+  "reactProfiler",
+  "skipInlineTransformWhilePlaying",
+  "disableVirtualization",
+  "freezeChordRepetitions",
+  "disableHighlightTransitions",
+  "disableSliderTransitions",
+  "skipLoopSliderReset",
+];
+
+const QUERY_ALIASES: Record<string, keyof PlaybackStutterDevFlags> = {
+  playbackStutterDebug: "debug",
+  playbackReactProfiler: "reactProfiler",
+  playbackSkipInlineTransform: "skipInlineTransformWhilePlaying",
+  playbackDisableVirtualization: "disableVirtualization",
+  playbackFreezeRepetitions: "freezeChordRepetitions",
+  playbackDisableHighlights: "disableHighlightTransitions",
+  playbackDisableSliderTransitions: "disableSliderTransitions",
+  playbackSkipLoopSliderReset: "skipLoopSliderReset",
+};
+
+function parseBool(value: string | string[] | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (raw === "1" || raw === "true") return true;
+  if (raw === "0" || raw === "false") return false;
+  return undefined;
+}
+
+function readSessionFlag(key: keyof PlaybackStutterDevFlags): boolean | null {
+  if (typeof window === "undefined") return null;
+  const stored = sessionStorage.getItem(`${SESSION_PREFIX}${key}`);
+  if (stored === "1") return true;
+  if (stored === "0") return false;
+  return null;
+}
+
+function writeSessionFlags(flags: PlaybackStutterDevFlags) {
+  if (typeof window === "undefined") return;
+  for (const key of FLAG_KEYS) {
+    sessionStorage.setItem(
+      `${SESSION_PREFIX}${key}`,
+      flags[key] ? "1" : "0",
+    );
+  }
+}
+
+function applyQueryToFlags(
+  query: Record<string, string | string[] | undefined>,
+  base: PlaybackStutterDevFlags,
+): PlaybackStutterDevFlags {
+  const next = { ...base };
+
+  for (const [queryKey, flagKey] of Object.entries(QUERY_ALIASES)) {
+    const parsed = parseBool(query[queryKey]);
+    if (parsed !== undefined) {
+      next[flagKey] = parsed;
+    }
+  }
+
+  // Shorthand: any playbackStutter* param turns debug on unless explicitly false
+  const debugParam = parseBool(query.playbackStutterDebug);
+  if (debugParam === true) {
+    next.debug = true;
+  }
+
+  return next;
+}
+
+let cachedFlags: PlaybackStutterDevFlags | null = null;
+
+export function getPlaybackStutterDevFlags(
+  query?: Record<string, string | string[] | undefined>,
+): PlaybackStutterDevFlags {
+  if (process.env.NODE_ENV === "production") {
+    return DEFAULT_FLAGS;
+  }
+
+  if (query) {
+    const fromSession = FLAG_KEYS.reduce((acc, key) => {
+      const stored = readSessionFlag(key);
+      if (stored !== null) acc[key] = stored;
+      return acc;
+    }, {} as Partial<PlaybackStutterDevFlags>);
+
+    const merged = { ...DEFAULT_FLAGS, ...fromSession };
+    const fromQuery = applyQueryToFlags(query, merged);
+    writeSessionFlags(fromQuery);
+    cachedFlags = fromQuery;
+    return fromQuery;
+  }
+
+  if (cachedFlags) return cachedFlags;
+
+  const fromSession = FLAG_KEYS.reduce((acc, key) => {
+    const stored = readSessionFlag(key);
+    if (stored !== null) acc[key] = stored;
+    return acc;
+  }, {} as Partial<PlaybackStutterDevFlags>);
+
+  cachedFlags = { ...DEFAULT_FLAGS, ...fromSession };
+  return cachedFlags;
+}
+
+export function isPlaybackStutterDebugEnabled(): boolean {
+  return getPlaybackStutterDevFlags().debug;
+}
+
+/**
+ * Omit React-managed inline transform while playing so WAAPI owns strip motion.
+ * Enabled in production. In dev, set playbackSkipInlineTransform=0 to restore old
+ * behavior for A/B comparison.
+ */
+export function shouldOmitInlineTransformWhilePlaying(playing: boolean): boolean {
+  if (!playing) return false;
+  if (process.env.NODE_ENV === "production") return true;
+  return getPlaybackStutterDevFlags().skipInlineTransformWhilePlaying;
+}

--- a/src/utils/playbackStutterDiagnostics.ts
+++ b/src/utils/playbackStutterDiagnostics.ts
@@ -1,0 +1,191 @@
+import { isPlaybackStutterDebugEnabled } from "~/utils/playbackStutterDevFlags";
+
+const MARK_PREFIX = "playback-stutter";
+
+export type PlaybackStutterEvent =
+  | "chord-index-set"
+  | "loop-boundary"
+  | "visible-range-compute"
+  | "chord-repetitions-primary"
+  | "chord-repetitions-catchup"
+  | "waapi-start"
+  | "waapi-cancel"
+  | "slider-loop-reset"
+  | "long-task";
+
+interface PlaybackStutterSample {
+  event: PlaybackStutterEvent;
+  timestamp: number;
+  durationMs?: number;
+  detail?: Record<string, number | string | boolean>;
+}
+
+const recentSamples: PlaybackStutterSample[] = [];
+const MAX_SAMPLES = 200;
+
+let longTaskObserver: PerformanceObserver | null = null;
+let lastChordIndex: number | null = null;
+let lastChordIndexTimestamp = 0;
+
+function pushSample(sample: PlaybackStutterSample) {
+  recentSamples.push(sample);
+  if (recentSamples.length > MAX_SAMPLES) {
+    recentSamples.shift();
+  }
+}
+
+export function markPlaybackStutter(
+  name: string,
+  detail?: Record<string, number | string | boolean>,
+) {
+  if (!isPlaybackStutterDebugEnabled()) return;
+
+  const markName = `${MARK_PREFIX}:${name}`;
+  performance.mark(markName);
+  pushSample({
+    event: name as PlaybackStutterEvent,
+    timestamp: performance.now(),
+    detail,
+  });
+}
+
+export function measurePlaybackStutter(
+  name: string,
+  startMark: string,
+  detail?: Record<string, number | string | boolean>,
+) {
+  if (!isPlaybackStutterDebugEnabled()) return;
+
+  const start = `${MARK_PREFIX}:${startMark}`;
+  const end = `${MARK_PREFIX}:${name}:end`;
+  performance.mark(end);
+
+  try {
+    performance.measure(`${MARK_PREFIX}:${name}`, start, end);
+    const entries = performance.getEntriesByName(`${MARK_PREFIX}:${name}`);
+    const durationMs = entries.at(-1)?.duration;
+
+    pushSample({
+      event: name as PlaybackStutterEvent,
+      timestamp: performance.now(),
+      durationMs,
+      detail,
+    });
+
+    if (durationMs !== undefined && durationMs > 8) {
+      console.warn(
+        `[playback-stutter] ${name} took ${durationMs.toFixed(1)}ms`,
+        detail ?? "",
+      );
+    }
+  } catch {
+    // measure() throws if marks are missing; ignore in dev tooling
+  }
+}
+
+export function recordChordIndexSet(chordIndex: number, playing: boolean) {
+  if (!isPlaybackStutterDebugEnabled()) return;
+
+  const now = performance.now();
+  const deltaSinceLastMs =
+    lastChordIndexTimestamp > 0 ? now - lastChordIndexTimestamp : undefined;
+
+  markPlaybackStutter("chord-index-set", {
+    chordIndex,
+    playing,
+    deltaSinceLastMs: deltaSinceLastMs ?? -1,
+  });
+
+  lastChordIndex = chordIndex;
+  lastChordIndexTimestamp = now;
+}
+
+export function recordLoopBoundary(detail: Record<string, number | string>) {
+  if (!isPlaybackStutterDebugEnabled()) return;
+
+  markPlaybackStutter("loop-boundary", detail);
+  console.info("[playback-stutter] loop boundary", detail);
+}
+
+export function startPlaybackStutterDiagnostics() {
+  if (!isPlaybackStutterDebugEnabled()) return;
+  if (typeof window === "undefined") return;
+  if (longTaskObserver) return;
+
+  try {
+    longTaskObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        pushSample({
+          event: "long-task",
+          timestamp: entry.startTime,
+          durationMs: entry.duration,
+        });
+
+        if (entry.duration > 16) {
+          const nearChord =
+            lastChordIndexTimestamp > 0
+              ? entry.startTime - lastChordIndexTimestamp
+              : null;
+
+          console.warn(
+            `[playback-stutter] long task ${entry.duration.toFixed(1)}ms` +
+              (nearChord !== null
+                ? ` (${nearChord.toFixed(0)}ms after chord index ${lastChordIndex})`
+                : ""),
+          );
+        }
+      }
+    });
+    longTaskObserver.observe({ type: "longtask", buffered: true });
+  } catch {
+    // longtask observer not supported in all environments
+  }
+
+  (window as unknown as { __playbackStutterDiagnostics?: unknown }).__playbackStutterDiagnostics =
+    {
+      getRecentSamples: () => [...recentSamples],
+      summarize: summarizePlaybackStutterDiagnostics,
+      clear: () => {
+        recentSamples.length = 0;
+        performance
+          .getEntriesByType("mark")
+          .filter((e) => e.name.startsWith(MARK_PREFIX))
+          .forEach((e) => performance.clearMarks(e.name));
+      },
+    };
+}
+
+export function summarizePlaybackStutterDiagnostics() {
+  const longTasks = recentSamples.filter((s) => s.event === "long-task");
+  const chordSets = recentSamples.filter((s) => s.event === "chord-index-set");
+  const loopBoundaries = recentSamples.filter((s) => s.event === "loop-boundary");
+  const visibleRange = recentSamples.filter(
+    (s) => s.event === "visible-range-compute",
+  );
+
+  const avgVisibleRangeMs =
+    visibleRange.length > 0
+      ? visibleRange.reduce((sum, s) => sum + (s.durationMs ?? 0), 0) /
+        visibleRange.length
+      : 0;
+
+  const summary = {
+    sampleCount: recentSamples.length,
+    longTaskCount: longTasks.length,
+    maxLongTaskMs: Math.max(0, ...longTasks.map((s) => s.durationMs ?? 0)),
+    chordIndexUpdates: chordSets.length,
+    loopBoundaries: loopBoundaries.length,
+    avgVisibleRangeComputeMs: avgVisibleRangeMs,
+    longTasksNearChordMs: longTasks
+      .map((task) => {
+        const priorChord = [...chordSets]
+          .reverse()
+          .find((c) => c.timestamp <= task.timestamp);
+        return priorChord ? task.timestamp - priorChord.timestamp : null;
+      })
+      .filter((v): v is number => v !== null && v < 50),
+  };
+
+  console.table(summary);
+  return summary;
+}

--- a/src/utils/playbackVisibleRange.ts
+++ b/src/utils/playbackVisibleRange.ts
@@ -23,9 +23,10 @@ function getChordPosition(
   );
 }
 
-/** Binary search for the first index whose position is >= target. */
+type PositionLookup = (index: number) => number;
+
 function lowerBound(
-  positions: number[],
+  getPosition: PositionLookup,
   target: number,
   start: number,
   end: number,
@@ -35,7 +36,7 @@ function lowerBound(
 
   while (lo < hi) {
     const mid = Math.floor((lo + hi) / 2);
-    if ((positions[mid] ?? 0) < target) {
+    if (getPosition(mid) < target) {
       lo = mid + 1;
     } else {
       hi = mid;
@@ -45,9 +46,8 @@ function lowerBound(
   return lo;
 }
 
-/** Binary search for the last index whose position is <= target. */
 function upperBound(
-  positions: number[],
+  getPosition: PositionLookup,
   target: number,
   start: number,
   end: number,
@@ -57,7 +57,7 @@ function upperBound(
 
   while (lo < hi) {
     const mid = Math.ceil((lo + hi) / 2);
-    if ((positions[mid] ?? 0) > target) {
+    if (getPosition(mid) > target) {
       hi = mid - 1;
     } else {
       lo = mid;
@@ -67,6 +67,20 @@ function upperBound(
   return lo;
 }
 
+/** Build absolute chord positions once; reuse across visible-range queries. */
+export function buildPlaybackChordPositions({
+  scrollPositions,
+  chordRepetitions,
+  totalWidth,
+}: Pick<
+  ComputePlaybackVisibleRangeArgs,
+  "scrollPositions" | "chordRepetitions" | "totalWidth"
+>): number[] {
+  return scrollPositions.map((position, index) =>
+    getChordPosition(index, scrollPositions, chordRepetitions, totalWidth),
+  );
+}
+
 export function computePlaybackVisibleRange({
   scrollPositions,
   chordRepetitions,
@@ -74,25 +88,30 @@ export function computePlaybackVisibleRange({
   currentChordIndex,
   visiblePlaybackContainerWidth,
   virtualizationBuffer,
-}: ComputePlaybackVisibleRangeArgs): PlaybackVisibleRange {
+  chordPositions,
+}: ComputePlaybackVisibleRangeArgs & {
+  chordPositions?: number[];
+}): PlaybackVisibleRange {
   const chordCount = scrollPositions.length;
   if (chordCount === 0) {
     return { startIndex: 0, endIndex: 0 };
   }
 
-  const positions = scrollPositions.map((position, index) =>
-    getChordPosition(index, scrollPositions, chordRepetitions, totalWidth),
-  );
+  const getPosition: PositionLookup =
+    chordPositions !== undefined
+      ? (index) => chordPositions[index] ?? 0
+      : (index) =>
+          getChordPosition(index, scrollPositions, chordRepetitions, totalWidth);
 
-  const currentScrollPosition = positions[currentChordIndex] ?? 0;
+  const currentScrollPosition = getPosition(currentChordIndex);
   const halfViewport = visiblePlaybackContainerWidth / 2;
   const minVisiblePosition =
     currentScrollPosition - halfViewport - virtualizationBuffer;
   const maxVisiblePosition =
     currentScrollPosition + halfViewport + virtualizationBuffer;
 
-  const rawStart = lowerBound(positions, minVisiblePosition, 0, chordCount - 1);
-  const rawEnd = upperBound(positions, maxVisiblePosition, 0, chordCount - 1);
+  const rawStart = lowerBound(getPosition, minVisiblePosition, 0, chordCount - 1);
+  const rawEnd = upperBound(getPosition, maxVisiblePosition, 0, chordCount - 1);
 
   return {
     startIndex: Math.max(0, rawStart - 1),

--- a/src/utils/playbackVisibleRange.ts
+++ b/src/utils/playbackVisibleRange.ts
@@ -1,0 +1,101 @@
+export interface PlaybackVisibleRange {
+  startIndex: number;
+  endIndex: number;
+}
+
+interface ComputePlaybackVisibleRangeArgs {
+  scrollPositions: number[];
+  chordRepetitions: number[];
+  totalWidth: number;
+  currentChordIndex: number;
+  visiblePlaybackContainerWidth: number;
+  virtualizationBuffer: number;
+}
+
+function getChordPosition(
+  index: number,
+  scrollPositions: number[],
+  chordRepetitions: number[],
+  totalWidth: number,
+) {
+  return (
+    (scrollPositions[index] ?? 0) + (chordRepetitions[index] ?? 0) * totalWidth
+  );
+}
+
+/** Binary search for the first index whose position is >= target. */
+function lowerBound(
+  positions: number[],
+  target: number,
+  start: number,
+  end: number,
+) {
+  let lo = start;
+  let hi = end;
+
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if ((positions[mid] ?? 0) < target) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  return lo;
+}
+
+/** Binary search for the last index whose position is <= target. */
+function upperBound(
+  positions: number[],
+  target: number,
+  start: number,
+  end: number,
+) {
+  let lo = start;
+  let hi = end;
+
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if ((positions[mid] ?? 0) > target) {
+      hi = mid - 1;
+    } else {
+      lo = mid;
+    }
+  }
+
+  return lo;
+}
+
+export function computePlaybackVisibleRange({
+  scrollPositions,
+  chordRepetitions,
+  totalWidth,
+  currentChordIndex,
+  visiblePlaybackContainerWidth,
+  virtualizationBuffer,
+}: ComputePlaybackVisibleRangeArgs): PlaybackVisibleRange {
+  const chordCount = scrollPositions.length;
+  if (chordCount === 0) {
+    return { startIndex: 0, endIndex: 0 };
+  }
+
+  const positions = scrollPositions.map((position, index) =>
+    getChordPosition(index, scrollPositions, chordRepetitions, totalWidth),
+  );
+
+  const currentScrollPosition = positions[currentChordIndex] ?? 0;
+  const halfViewport = visiblePlaybackContainerWidth / 2;
+  const minVisiblePosition =
+    currentScrollPosition - halfViewport - virtualizationBuffer;
+  const maxVisiblePosition =
+    currentScrollPosition + halfViewport + virtualizationBuffer;
+
+  const rawStart = lowerBound(positions, minVisiblePosition, 0, chordCount - 1);
+  const rawEnd = upperBound(positions, maxVisiblePosition, 0, chordCount - 1);
+
+  return {
+    startIndex: Math.max(0, rawStart - 1),
+    endIndex: Math.min(chordCount - 1, rawEnd + 1),
+  };
+}

--- a/src/utils/tabSliderHelpers.ts
+++ b/src/utils/tabSliderHelpers.ts
@@ -1,4 +1,7 @@
-function resetProgressTabSliderPosition(type: "editing" | "playback") {
+import { getPlaybackStutterDevFlags } from "~/utils/playbackStutterDevFlags";
+import { markPlaybackStutter } from "~/utils/playbackStutterDiagnostics";
+
+function resetProgressTabSliderPositionSync(type: "editing" | "playback") {
   const track = document.getElementById(
     type === "editing" ? "editingSliderTrack" : "playbackSliderTrack",
   );
@@ -23,6 +26,23 @@ function resetProgressTabSliderPosition(type: "editing" | "playback") {
   // re-apply the transition on the next frame after resetting the position
   track.style.transitionDuration = prevTransitionDuration;
   thumb.style.transitionDuration = prevTransitionDuration;
+}
+
+function resetProgressTabSliderPosition(type: "editing" | "playback") {
+  if (
+    process.env.NODE_ENV !== "production" &&
+    getPlaybackStutterDevFlags().skipLoopSliderReset
+  ) {
+    return;
+  }
+
+  markPlaybackStutter("slider-loop-reset", { type });
+
+  // Defer to the next frame so the reset does not run in the same turn as audio
+  // scheduling and store updates at loop boundaries.
+  requestAnimationFrame(() => {
+    resetProgressTabSliderPositionSync(type);
+  });
 }
 
 export { resetProgressTabSliderPosition };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigates and addresses occasional animation hitches during playback modal tab scrolling. The root causes were residual per-chord main-thread work competing with WAAPI strip animation, plus loop-boundary work stacking (forced reflow, WAAPI restart).

### Production fixes
- **Omit inline `transform` while playing** — WAAPI now exclusively owns strip motion during playback; inline transform is only applied when paused/scrubbing.
- **Extract `PlaybackChordStrip`** — per-chord store updates re-render only the strip subtree, not the full modal shell.
- **Binary-search visible range** — replaces O(n) linear scan on every chord (`playbackVisibleRange.ts`).
- **Loop-boundary improvements**
  - Defer `resetProgressTabSliderPosition` to `requestAnimationFrame` to avoid blocking the same turn as audio scheduling.
  - In playback modal loops, stop resetting `playbackStartedAtAudioTime` so WAAPI is not cancelled/restarted at every loop seam (WAAPI `onfinish` chains loops on the compositor).

### Diagnostics (dev only)
- `playbackStutterDiagnostics.ts` — `performance.mark()` instrumentation, long-task observer, `__playbackStutterDiagnostics.summarize()` console helper.
- `playbackStutterDevFlags.ts` — URL/session A/B toggles for bisecting causes (virtualization, highlights, slider transitions, etc.).
- `/dev-playback-stutter-harness` — seeds a tab fixture, opens the playback modal, documents query params for profiling.
- `scripts/verifyPlaybackVisibleRange.mjs` — verifies binary-search visible range against brute-force reference (2457 cases).

### How to profile locally
```
/dev-playback-stutter-harness?playbackStutterDebug=1&playbackReactProfiler=1
```
Then play back and run `__playbackStutterDiagnostics.summarize()` in the console.

### A/B toggles (dev)
| Param | Effect |
|-------|--------|
| `playbackSkipInlineTransform=0` | Restore pre-fix inline transform during play |
| `playbackDisableVirtualization=1` | Render all chords |
| `playbackFreezeRepetitions=1` | Skip loop repetition batch updates |
| `playbackDisableHighlights=1` | Zero highlight transition duration |
| `playbackDisableSliderTransitions=1` | Disable slider CSS transitions |
| `playbackSkipLoopSliderReset=1` | Skip loop slider reset |

## Test plan
- [x] `node scripts/verifyPlaybackVisibleRange.mjs` (2457 passed)
- [ ] Manual: play back a tab in the modal — strip scroll should be smooth with no hitches at chord boundaries
- [ ] Manual: verify loop wrap is seamless (no visible snap at loop seam)
- [ ] Manual: pause/scrub still positions strip correctly
- [ ] Dev harness: `/dev-playback-stutter-harness?playbackStutterDebug=1` — confirm diagnostics output during playback

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dffbcc2f-ef88-4cc4-babd-b7e25b0dd99f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dffbcc2f-ef88-4cc4-babd-b7e25b0dd99f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

