### PR TITLE
Fix playback modal tab disappearing after loop when scrubbing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2221,9 +2221,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2239,9 +2236,6 @@
       "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2259,9 +2253,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2277,9 +2268,6 @@
       "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/components/AudioControls/PlaybackProgressSlider.tsx
+++ b/src/components/AudioControls/PlaybackProgressSlider.tsx
@@ -230,10 +230,20 @@ function PlaybackProgressSlider({
 
             if (values[0] === undefined) return;
 
-            // Virtualization only handles forward playback movement, so reset on any manual scrub.
-            setChordRepetitions(new Array(scrollPositionsLength).fill(0));
+            const nextIndex = values[0];
+            if (nextIndex === currentChordIndex) return;
 
-            setCurrentChordIndex(values[0]);
+            // Clear stale virtualization offsets when manually seeking. Skip if already reset
+            // to avoid re-render loops with the virtualization effects in PlaybackModal.
+            setChordRepetitions((prev) => {
+              if (prev.length === 0 || prev.every((repetition) => repetition === 0)) {
+                return prev;
+              }
+
+              return new Array(scrollPositionsLength).fill(0);
+            });
+
+            setCurrentChordIndex(nextIndex);
           }}
           renderTrack={({ props, children, disabled }) => (
             <div

--- a/src/components/AudioControls/PlaybackProgressSlider.tsx
+++ b/src/components/AudioControls/PlaybackProgressSlider.tsx
@@ -230,11 +230,8 @@ function PlaybackProgressSlider({
 
             if (values[0] === undefined) return;
 
-            if (values[0] < currentChordIndex) {
-              // virtualization logic is set up to handle "forward" movement only, so we need to reset
-              // whenever we move backwards to ensure the correct chords are rendered
-              setChordRepetitions(new Array(scrollPositionsLength).fill(0));
-            }
+            // Virtualization only handles forward playback movement, so reset on any manual scrub.
+            setChordRepetitions(new Array(scrollPositionsLength).fill(0));
 
             setCurrentChordIndex(values[0]);
           }}

--- a/src/components/Tab/Playback/PlaybackAudio/PlaybackAudioControls.tsx
+++ b/src/components/Tab/Playback/PlaybackAudio/PlaybackAudioControls.tsx
@@ -370,7 +370,16 @@ function PlaybackAudioControls({
                       i--;
                     }
 
-                    setChordRepetitions(new Array(scrollPositionsLength).fill(0));
+                    setChordRepetitions((prev) => {
+                      if (
+                        prev.length === 0 ||
+                        prev.every((repetition) => repetition === 0)
+                      ) {
+                        return prev;
+                      }
+
+                      return new Array(scrollPositionsLength).fill(0);
+                    });
                     setCurrentChordIndex(i);
                   }}
                   className="size-4 shrink-0 rounded-full bg-transparent p-0"
@@ -433,7 +442,16 @@ function PlaybackAudioControls({
                       i++;
                     }
 
-                    setChordRepetitions(new Array(scrollPositionsLength).fill(0));
+                    setChordRepetitions((prev) => {
+                      if (
+                        prev.length === 0 ||
+                        prev.every((repetition) => repetition === 0)
+                      ) {
+                        return prev;
+                      }
+
+                      return new Array(scrollPositionsLength).fill(0);
+                    });
                     setCurrentChordIndex(i);
                   }}
                   className="size-4 shrink-0 rounded-full bg-transparent p-0"

--- a/src/components/Tab/Playback/PlaybackAudio/PlaybackAudioControls.tsx
+++ b/src/components/Tab/Playback/PlaybackAudio/PlaybackAudioControls.tsx
@@ -370,6 +370,7 @@ function PlaybackAudioControls({
                       i--;
                     }
 
+                    setChordRepetitions(new Array(scrollPositionsLength).fill(0));
                     setCurrentChordIndex(i);
                   }}
                   className="size-4 shrink-0 rounded-full bg-transparent p-0"
@@ -432,6 +433,7 @@ function PlaybackAudioControls({
                       i++;
                     }
 
+                    setChordRepetitions(new Array(scrollPositionsLength).fill(0));
                     setCurrentChordIndex(i);
                   }}
                   className="size-4 shrink-0 rounded-full bg-transparent p-0"

--- a/src/components/Tab/Playback/PlaybackModal.tsx
+++ b/src/components/Tab/Playback/PlaybackModal.tsx
@@ -266,17 +266,23 @@ function PlaybackModal() {
     visiblePlaybackContainerWidth,
   ]);
 
+  // Virtualized repetition offsets are only meaningful during active playback.
+  // After a loop completes, currentChordIndex resets while chordRepetitions stay
+  // elevated, which pushes the paused/scrubbed strip off-screen if we keep using them.
+  const useVirtualizedRepetitions = audioMetadata.playing;
+
   // Helper to compute scroll position for a chord using chordRepetitions
   const getChordScrollPosition = useCallback(
     (index: number) => {
       if (!chordLayoutData) return 0;
       const { scrollPositions, totalWidth } = chordLayoutData;
-      return (
-        (scrollPositions[index] ?? 0) +
-        (chordRepetitions[index] ?? 0) * totalWidth
-      );
+      const repetitionOffset = useVirtualizedRepetitions
+        ? (chordRepetitions[index] ?? 0) * totalWidth
+        : 0;
+
+      return (scrollPositions[index] ?? 0) + repetitionOffset;
     },
-    [chordLayoutData, chordRepetitions],
+    [chordLayoutData, chordRepetitions, useVirtualizedRepetitions],
   );
 
   // Compute visible chord range using binary search with chordRepetitions
@@ -300,10 +306,13 @@ function PlaybackModal() {
     const { scrollPositions, totalWidth } = chordLayoutData;
     const chordCount = expandedTabData.length;
 
+    const currentRepetitionOffset = useVirtualizedRepetitions
+      ? (chordRepetitions[currentChordIndex] ?? 0) * totalWidth
+      : 0;
+
     // Get current chord's scroll position using its repetition count
     const currentScrollPosition =
-      (scrollPositions[currentChordIndex] ?? 0) +
-      (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
+      (scrollPositions[currentChordIndex] ?? 0) + currentRepetitionOffset;
 
     const halfViewport = visiblePlaybackContainerWidth / 2;
     const minVisiblePosition =
@@ -317,8 +326,10 @@ function PlaybackModal() {
 
     // Find start index
     for (let i = 0; i < chordCount; i++) {
-      const chordPosition =
-        (scrollPositions[i] ?? 0) + (chordRepetitions[i] ?? 0) * totalWidth;
+      const repetitionOffset = useVirtualizedRepetitions
+        ? (chordRepetitions[i] ?? 0) * totalWidth
+        : 0;
+      const chordPosition = (scrollPositions[i] ?? 0) + repetitionOffset;
       if (chordPosition >= minVisiblePosition) {
         startIndex = Math.max(0, i - 1);
         break;
@@ -327,8 +338,10 @@ function PlaybackModal() {
 
     // Find end index
     for (let i = chordCount - 1; i >= 0; i--) {
-      const chordPosition =
-        (scrollPositions[i] ?? 0) + (chordRepetitions[i] ?? 0) * totalWidth;
+      const repetitionOffset = useVirtualizedRepetitions
+        ? (chordRepetitions[i] ?? 0) * totalWidth
+        : 0;
+      const chordPosition = (scrollPositions[i] ?? 0) + repetitionOffset;
       if (chordPosition <= maxVisiblePosition) {
         endIndex = Math.min(chordCount - 1, i + 1);
         break;
@@ -346,6 +359,7 @@ function PlaybackModal() {
     visiblePlaybackContainerWidth,
     currentChordIndex,
     chordRepetitions,
+    useVirtualizedRepetitions,
   ]);
 
   // Primary chord virtualization effect - increments all chords except the last visible portion
@@ -456,9 +470,10 @@ function PlaybackModal() {
       return "translateX(0px)";
 
     const { scrollPositions, totalWidth } = chordLayoutData;
-    const position =
-      (scrollPositions[currentChordIndex] ?? 0) +
-      (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
+    const repetitionOffset = useVirtualizedRepetitions
+      ? (chordRepetitions[currentChordIndex] ?? 0) * totalWidth
+      : 0;
+    const position = (scrollPositions[currentChordIndex] ?? 0) + repetitionOffset;
 
     return `translateX(${position * -1}px)`;
   }, [
@@ -467,6 +482,7 @@ function PlaybackModal() {
     currentlyPlayingMetadata,
     currentChordIndex,
     chordRepetitions,
+    useVirtualizedRepetitions,
   ]);
 
   const isChordHighlighted = useCallback(
@@ -477,6 +493,10 @@ function PlaybackModal() {
         chordRepetitions.length === 0
       )
         return false;
+
+      if (!audioMetadata.playing) {
+        return chordIndex <= currentChordIndex;
+      }
 
       if (currentChordIndex === chordIndex && audioMetadata.playing) {
         return true;

--- a/src/components/Tab/Playback/PlaybackModal.tsx
+++ b/src/components/Tab/Playback/PlaybackModal.tsx
@@ -366,6 +366,7 @@ function PlaybackModal() {
   // Triggers when current chord index reaches the point where the last chord becomes visible
   useEffect(() => {
     if (
+      !audioMetadata.playing ||
       !chordLayoutData ||
       chordRepetitions.length === 0 ||
       currentChordIndex < chordLayoutData.virtualizationIndex ||
@@ -389,12 +390,18 @@ function PlaybackModal() {
 
       return [...firstNewHalf, ...secondNewHalf];
     });
-  }, [chordLayoutData, chordRepetitions, currentChordIndex]);
+  }, [
+    audioMetadata.playing,
+    chordLayoutData,
+    chordRepetitions,
+    currentChordIndex,
+  ]);
 
   // Catchup chord virtualization effect - increments the remaining chords after they leave the viewport
   // Triggers after the beginning of the tab leaves the viewport on a new loop
   useEffect(() => {
     if (
+      !audioMetadata.playing ||
       !chordLayoutData ||
       chordRepetitions.length === 0 ||
       // making sure that this only happens post-primary virtualization and not
@@ -410,7 +417,12 @@ function PlaybackModal() {
       const newRepetitions = prev[0] ?? 0;
       return new Array(prev.length).fill(newRepetitions) as number[];
     });
-  }, [chordLayoutData, chordRepetitions, currentChordIndex]);
+  }, [
+    audioMetadata.playing,
+    chordLayoutData,
+    chordRepetitions,
+    currentChordIndex,
+  ]);
 
   // Handle resize
   useEffect(() => {

--- a/src/components/Tab/Playback/PlaybackScrollingContainer.tsx
+++ b/src/components/Tab/Playback/PlaybackScrollingContainer.tsx
@@ -42,11 +42,16 @@ function PlaybackScrollingContainer({
   const startXRef = useRef(0);
   const isTouchingRef = useRef(false);
 
+  function resetChordRepetitions() {
+    setChordRepetitions(new Array(scrollPositionsLength).fill(0));
+  }
+
   // Helper to increment chord index (with wrap to 0 if we're at the end).
   function incrementChordIndex() {
     if (expandedTabData === null) return;
 
     const newValue = currentChordIndex + 1;
+    resetChordRepetitions();
     setCurrentChordIndex(newValue > expandedTabData.length - 1 ? 0 : newValue);
   }
 
@@ -58,6 +63,7 @@ function PlaybackScrollingContainer({
 
     if (newValue < 0 && loopCount === 0) return;
 
+    resetChordRepetitions();
     setCurrentChordIndex(newValue < 0 ? expandedTabData.length - 1 : newValue);
   }
 
@@ -79,10 +85,6 @@ function PlaybackScrollingContainer({
     // If we've passed a 15px threshold to the left or right, increment or decrement
     if (deltaX > 15) {
       decrementChordIndex(); // moving right -> chord index goes down
-
-      // virtualization logic is set up to handle "forward" movement only, so we need to reset
-      // whenever we move backwards to ensure the correct chords are rendered
-      setChordRepetitions(new Array(scrollPositionsLength).fill(0));
 
       startXRef.current = e.clientX; // reset the start so you can scroll again
     } else if (deltaX < -15) {

--- a/src/components/Tab/Playback/PlaybackScrollingContainer.tsx
+++ b/src/components/Tab/Playback/PlaybackScrollingContainer.tsx
@@ -42,8 +42,14 @@ function PlaybackScrollingContainer({
   const startXRef = useRef(0);
   const isTouchingRef = useRef(false);
 
-  function resetChordRepetitions() {
-    setChordRepetitions(new Array(scrollPositionsLength).fill(0));
+  function resetChordRepetitionsIfNeeded() {
+    setChordRepetitions((prev) => {
+      if (prev.length === 0 || prev.every((repetition) => repetition === 0)) {
+        return prev;
+      }
+
+      return new Array(scrollPositionsLength).fill(0);
+    });
   }
 
   // Helper to increment chord index (with wrap to 0 if we're at the end).
@@ -51,7 +57,7 @@ function PlaybackScrollingContainer({
     if (expandedTabData === null) return;
 
     const newValue = currentChordIndex + 1;
-    resetChordRepetitions();
+    resetChordRepetitionsIfNeeded();
     setCurrentChordIndex(newValue > expandedTabData.length - 1 ? 0 : newValue);
   }
 
@@ -63,7 +69,7 @@ function PlaybackScrollingContainer({
 
     if (newValue < 0 && loopCount === 0) return;
 
-    resetChordRepetitions();
+    resetChordRepetitionsIfNeeded();
     setCurrentChordIndex(newValue < 0 ? expandedTabData.length - 1 : newValue);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After a full loop finishes in the playback modal, scrubbing (via the progress slider, swipe gestures, or ±5s buttons) could cause the tab strip to disappear.

## Root cause

The modal uses `chordRepetitions` to virtualize infinite scrolling during playback. When a loop completes, `playTab` resets `currentChordIndex` to `0`, but `chordRepetitions` stays elevated from the virtualization that ran during the loop.

Once playback pauses or the user scrubs manually, the CSS `translateX` transform still applied those repetition offsets. At index `0` with repetition `1`, the strip was shifted by a full tab width off-screen.

Manual scrubbing only reset `chordRepetitions` on backward movement, so forward scrubbing after a loop left the stale virtualization state in place.

## Fix

1. **Ignore repetition offsets while paused** — scroll position, visible range, and highlighting now use base chord positions when `audioMetadata.playing` is false.
2. **Reset repetitions on any manual seek** — the progress slider, swipe container, and ±5s buttons all reset `chordRepetitions` to zero whenever the user manually changes position.

## Files changed

- `src/components/Tab/Playback/PlaybackModal.tsx`
- `src/components/AudioControls/PlaybackProgressSlider.tsx`
- `src/components/Tab/Playback/PlaybackScrollingContainer.tsx`
- `src/components/Tab/Playback/PlaybackAudio/PlaybackAudioControls.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bbba60b-9d74-43f2-a81d-b2ee145fc0e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bbba60b-9d74-43f2-a81d-b2ee145fc0e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

