### PR TITLE
Fix playback chord culling after loop while paused

### DIFF
--- a/scripts/verifyPlaybackChordVirtualization.mjs
+++ b/scripts/verifyPlaybackChordVirtualization.mjs
@@ -1,0 +1,253 @@
+// End-to-end verification of playback chord virtualization after loop + pause.
+//
+// Usage:
+//   1. start the dev server (npm run dev)
+//   2. node scripts/verifyPlaybackChordVirtualization.mjs [baseURL]
+//
+// Exits non-zero if any assertion fails.
+
+import { chromium } from "playwright";
+
+const BASE = process.argv[2] ?? "http://localhost:3000";
+const HARNESS = `${BASE}/dev-playback-harness`;
+
+const failures = [];
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (condition) {
+    console.log(`  PASS  ${message}`);
+  } else {
+    failures.push(message);
+    console.log(`  FAIL  ${message}`);
+  }
+}
+
+async function openHarness(page, query, viewport) {
+  await page.setViewportSize(viewport);
+  await page.goto(`${HARNESS}?${query}`, { waitUntil: "networkidle" });
+  await page.waitForSelector('#devPlaybackHarness[data-ready="true"]');
+  await page.waitForTimeout(1000);
+}
+
+async function readHarnessState(page) {
+  return page.evaluate(() => {
+    const harness = window.__playbackHarness;
+    if (!harness) return null;
+
+    const strip = document.querySelector("[data-playback-strip]");
+    const stripRect = strip?.parentElement?.getBoundingClientRect();
+    const playheadX = stripRect
+      ? stripRect.left + stripRect.width / 2
+      : window.innerWidth / 2;
+
+    const chordBoundingBoxes = harness.mountedChordIndices.map((index) => {
+      const element = document.querySelector(
+        `[data-testid="playback-chord-${index}"]`,
+      );
+      const rect = element?.getBoundingClientRect();
+      return {
+        index,
+        left: rect?.left ?? -1,
+        right: rect?.right ?? -1,
+      };
+    });
+
+    return {
+      ...harness,
+      playheadX,
+      chordBoundingBoxes,
+    };
+  });
+}
+
+async function testSplitRepDeadZone(browser, viewportName, viewport) {
+  console.log(`\n--- split-rep dead zone viewport=${viewportName} ---`);
+
+  const context = await browser.newContext({ viewport });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+  page.on("pageerror", (err) => {
+    failures.push(`pageerror: ${err.message}`);
+  });
+
+  await openHarness(page, "fixture=long&repState=split&chordIndex=0", viewport);
+  const state = await readHarnessState(page);
+
+  assert(state !== null, "window.__playbackHarness is available");
+  if (!state) {
+    await context.close();
+    return;
+  }
+
+  assert(
+    state.currentChordIndex === 0,
+    `playhead at index 0 (got ${state.currentChordIndex})`,
+  );
+  assert(
+    state.chordRepetitions[0] !== state.chordRepetitions.at(-1),
+    "chord repetitions are split",
+  );
+  assert(
+    state.mountedChordIndices.some(
+      (index) => index >= state.virtualizationStartIndex,
+    ),
+    `mounted chords include tail indices >= virtualizationStartIndex (${state.virtualizationStartIndex})`,
+  );
+
+  const behindPlayhead = state.chordBoundingBoxes.filter(
+    (box) => box.right > 0 && box.right <= state.playheadX + 4,
+  );
+  assert(
+    behindPlayhead.length > 0,
+    `at least one mounted chord is rendered behind the playhead (${behindPlayhead.length}, last=${state.chordBoundingBoxes.at(-1)?.right ?? "n/a"})`,
+  );
+
+  await context.close();
+}
+
+async function testUnifiedBaseline(browser, viewportName, viewport) {
+  console.log(`\n--- unified reps baseline viewport=${viewportName} ---`);
+
+  const context = await browser.newContext({ viewport });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  await openHarness(
+    page,
+    "fixture=long&repState=unified&chordIndex=50",
+    viewport,
+  );
+  const state = await readHarnessState(page);
+
+  assert(state !== null, "harness snapshot available for unified reps");
+  if (!state) {
+    await context.close();
+    return;
+  }
+
+  assert(
+    state.chordRepetitions[0] === state.chordRepetitions.at(-1),
+    "chord repetitions are unified",
+  );
+  assert(
+    state.mountedChordIndices.includes(50),
+    "current chord index is mounted",
+  );
+  assert(
+    state.mountedChordIndices.some((index) => index < 50) &&
+      state.mountedChordIndices.some((index) => index > 50),
+    "neighbors on both sides of the playhead are mounted",
+  );
+
+  await context.close();
+}
+
+async function testCatchupWindow(browser, viewportName, viewport) {
+  console.log(`\n--- split reps at catchup index viewport=${viewportName} ---`);
+
+  const context = await browser.newContext({ viewport });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  await openHarness(page, "fixture=long&repState=split&chordIndex=0", viewport);
+  const bootstrap = await readHarnessState(page);
+  assert(bootstrap !== null, "bootstrap harness snapshot available");
+
+  if (!bootstrap) {
+    await context.close();
+    return;
+  }
+
+  const catchupIndex = bootstrap.virtualizationCatchupIndex;
+  await openHarness(
+    page,
+    `fixture=long&repState=split&chordIndex=${catchupIndex}`,
+    viewport,
+  );
+  const state = await readHarnessState(page);
+
+  assert(state !== null, "catchup harness snapshot available");
+  if (!state) {
+    await context.close();
+    return;
+  }
+
+  assert(
+    state.currentChordIndex === catchupIndex,
+    `playhead at catchup index ${catchupIndex}`,
+  );
+  assert(
+    state.mountedChordIndices.includes(catchupIndex),
+    "catchup index chord is mounted",
+  );
+  assert(
+    state.mountedChordCount > 0,
+    `mounted chord count is nonzero (${state.mountedChordCount})`,
+  );
+
+  await context.close();
+}
+
+async function testPausedStripTransform(browser, viewportName, viewport) {
+  console.log(`\n--- paused strip transform viewport=${viewportName} ---`);
+
+  const context = await browser.newContext({ viewport });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  await openHarness(page, "fixture=long&repState=split&chordIndex=0", viewport);
+  const state = await readHarnessState(page);
+
+  assert(state !== null, "paused strip snapshot available");
+  if (!state) {
+    await context.close();
+    return;
+  }
+
+  assert(
+    typeof state.stripTransform === "string" &&
+      state.stripTransform.startsWith("translateX("),
+    `strip uses translateX while paused (${state.stripTransform})`,
+  );
+
+  await context.close();
+}
+
+const browser = await chromium.launch();
+
+try {
+  const desktop = { width: 1280, height: 800 };
+  const mobile = { width: 390, height: 844 };
+
+  for (const viewport of [
+    ["desktop", desktop],
+    ["mobile", mobile],
+  ]) {
+    const [name, size] = viewport;
+    await testSplitRepDeadZone(browser, name, size);
+    await testUnifiedBaseline(browser, name, size);
+    await testCatchupWindow(browser, name, size);
+    await testPausedStripTransform(browser, name, size);
+  }
+
+  console.log(`\n${checks - failures.length}/${checks} checks passed`);
+} finally {
+  await browser.close();
+}
+
+if (failures.length > 0) {
+  console.error(`\nFAILED:\n- ${failures.join("\n- ")}`);
+  process.exit(1);
+}
+
+console.log("ALL CHECKS PASSED");

--- a/src/components/Tab/Playback/PlaybackModal.tsx
+++ b/src/components/Tab/Playback/PlaybackModal.tsx
@@ -20,6 +20,7 @@ import { X } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import useModalScrollbarHandling from "~/hooks/useModalScrollbarHandling";
 import usePlaybackStripAnimation from "~/hooks/usePlaybackStripAnimation";
+import { getPlaybackVisibleRange } from "~/utils/playbackVisibleRange";
 
 const backdropVariants = {
   expanded: {
@@ -32,6 +33,25 @@ const backdropVariants = {
 
 const VIRTUALIZATION_BUFFER = 100;
 
+export interface PlaybackModalDevSeed {
+  chordRepetitions: number[];
+  currentChordIndex: number;
+}
+
+export interface PlaybackHarnessSnapshot {
+  chordRepetitions: number[];
+  currentChordIndex: number;
+  visibleRange: { startIndex: number; endIndex: number };
+  virtualizationStartIndex: number;
+  virtualizationCatchupIndex: number;
+  mountedChordIndices: number[];
+}
+
+interface PlaybackModalProps {
+  devSeed?: PlaybackModalDevSeed;
+  onDevStateSnapshot?: (snapshot: PlaybackHarnessSnapshot) => void;
+}
+
 interface ChordLayoutData {
   scrollPositions: number[];
   chordWidths: number[];
@@ -43,7 +63,7 @@ interface ChordLayoutData {
   virtualizationCatchupIndex: number; // Index where the beginning of the tab leaves the viewport
 }
 
-function PlaybackModal() {
+function PlaybackModal({ devSeed, onDevStateSnapshot }: PlaybackModalProps = {}) {
   const {
     currentChordIndex,
     expandedTabData,
@@ -101,6 +121,11 @@ function PlaybackModal() {
   // Per-chord repetition tracking for smooth infinite scroll without visual snapping
   // Each chord tracks how many times it has "looped" for positioning purposes
   const [chordRepetitions, setChordRepetitions] = useState<number[]>([]);
+  const [pausedStripSnapshot, setPausedStripSnapshot] = useState<{
+    positionPx: number;
+    chordIndex: number;
+    repetition: number;
+  } | null>(null);
 
   // v avoids polluting the store with these extra semi-local values
   const [loopRange, setLoopRange] = useState<[number, number]>([
@@ -131,10 +156,17 @@ function PlaybackModal() {
 
   // Initialize chordRepetitions when expandedTabData changes
   useEffect(() => {
-    if (expandedTabData && expandedTabData.length > 0) {
-      setChordRepetitions(new Array(expandedTabData.length).fill(0));
+    if (!expandedTabData || expandedTabData.length === 0) return;
+
+    if (devSeed?.chordRepetitions.length === expandedTabData.length) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- dev harness seed sync
+      setChordRepetitions(devSeed.chordRepetitions);
+      setCurrentChordIndex(devSeed.currentChordIndex);
+      return;
     }
-  }, [expandedTabData]);
+
+    setChordRepetitions(new Array(expandedTabData.length).fill(0));
+  }, [expandedTabData, devSeed, setCurrentChordIndex]);
 
   // Compute chord layout data (positions, widths, durations) - memoized
   const chordLayoutData = useMemo<ChordLayoutData | null>(() => {
@@ -297,48 +329,14 @@ function PlaybackModal() {
       };
     }
 
-    const { scrollPositions, totalWidth } = chordLayoutData;
-    const chordCount = expandedTabData.length;
-
-    // Get current chord's scroll position using its repetition count
-    const currentScrollPosition =
-      (scrollPositions[currentChordIndex] ?? 0) +
-      (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
-
-    const halfViewport = visiblePlaybackContainerWidth / 2;
-    const minVisiblePosition =
-      currentScrollPosition - halfViewport - VIRTUALIZATION_BUFFER;
-    const maxVisiblePosition =
-      currentScrollPosition + halfViewport + VIRTUALIZATION_BUFFER;
-
-    // Find visible range - we need to check each chord's actual position with its repetition
-    let startIndex = 0;
-    let endIndex = chordCount - 1;
-
-    // Find start index
-    for (let i = 0; i < chordCount; i++) {
-      const chordPosition =
-        (scrollPositions[i] ?? 0) + (chordRepetitions[i] ?? 0) * totalWidth;
-      if (chordPosition >= minVisiblePosition) {
-        startIndex = Math.max(0, i - 1);
-        break;
-      }
-    }
-
-    // Find end index
-    for (let i = chordCount - 1; i >= 0; i--) {
-      const chordPosition =
-        (scrollPositions[i] ?? 0) + (chordRepetitions[i] ?? 0) * totalWidth;
-      if (chordPosition <= maxVisiblePosition) {
-        endIndex = Math.min(chordCount - 1, i + 1);
-        break;
-      }
-    }
-
-    return {
-      startIndex,
-      endIndex,
-    };
+    return getPlaybackVisibleRange({
+      layout: chordLayoutData,
+      chordCount: expandedTabData.length,
+      currentChordIndex,
+      chordRepetitions,
+      visiblePlaybackContainerWidth,
+      virtualizationBuffer: VIRTUALIZATION_BUFFER,
+    });
   }, [
     chordLayoutData,
     expandedTabData,
@@ -434,6 +432,17 @@ function PlaybackModal() {
 
   const currentChordRepetition = chordRepetitions[currentChordIndex] ?? 0;
 
+  const handlePauseTransform = useCallback(
+    (positionPx: number) => {
+      setPausedStripSnapshot({
+        positionPx,
+        chordIndex: currentChordIndex,
+        repetition: currentChordRepetition,
+      });
+    },
+    [currentChordIndex, currentChordRepetition],
+  );
+
   usePlaybackStripAnimation({
     stripRef: scrollStripRef,
     chordLayoutData,
@@ -442,6 +451,7 @@ function PlaybackModal() {
     audioContext,
     playbackStartedAtAudioTime,
     playing: audioMetadata.playing,
+    onPauseTransform: handlePauseTransform,
   });
 
   // Keep the inline transform at the current chord boundary.
@@ -456,9 +466,15 @@ function PlaybackModal() {
       return "translateX(0px)";
 
     const { scrollPositions, totalWidth } = chordLayoutData;
+    const pausedOffsetMatches =
+      pausedStripSnapshot !== null &&
+      pausedStripSnapshot.chordIndex === currentChordIndex &&
+      pausedStripSnapshot.repetition === currentChordRepetition;
     const position =
-      (scrollPositions[currentChordIndex] ?? 0) +
-      (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
+      !audioMetadata.playing && pausedOffsetMatches
+        ? pausedStripSnapshot.positionPx
+        : (scrollPositions[currentChordIndex] ?? 0) +
+          (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
 
     return `translateX(${position * -1}px)`;
   }, [
@@ -467,6 +483,9 @@ function PlaybackModal() {
     currentlyPlayingMetadata,
     currentChordIndex,
     chordRepetitions,
+    audioMetadata.playing,
+    pausedStripSnapshot,
+    currentChordRepetition,
   ]);
 
   const isChordHighlighted = useCallback(
@@ -542,6 +561,26 @@ function PlaybackModal() {
 
     return result;
   }, [expandedTabData, chordLayoutData, visibleRange]);
+
+  useEffect(() => {
+    if (!onDevStateSnapshot || !chordLayoutData) return;
+
+    onDevStateSnapshot({
+      chordRepetitions,
+      currentChordIndex,
+      visibleRange,
+      virtualizationStartIndex: chordLayoutData.virtualizationStartIndex,
+      virtualizationCatchupIndex: chordLayoutData.virtualizationCatchupIndex,
+      mountedChordIndices: visibleChords.map(({ index }) => index),
+    });
+  }, [
+    onDevStateSnapshot,
+    chordLayoutData,
+    chordRepetitions,
+    currentChordIndex,
+    visibleRange,
+    visibleChords,
+  ]);
 
   return (
     <motion.div
@@ -632,6 +671,7 @@ function PlaybackModal() {
                       {chordLayoutData && expandedTabData && (
                         <div
                           ref={scrollStripRef}
+                          data-playback-strip
                           style={{
                             width: `${chordLayoutData.totalWidth}px`,
                             transform: scrollContainerTransform,
@@ -668,6 +708,7 @@ function PlaybackModal() {
                               return (
                                 <div
                                   key={`${index}-${chordRepetitions[index] ?? 0}`}
+                                  data-testid={`playback-chord-${index}`}
                                   style={{
                                     position: "absolute",
                                     width: `${chordLayoutData.chordWidths[index] ?? 0}px`,

--- a/src/hooks/usePlaybackStripAnimation.ts
+++ b/src/hooks/usePlaybackStripAnimation.ts
@@ -20,6 +20,7 @@ interface UsePlaybackStripAnimationArgs {
   audioContext: AudioContext | null;
   playbackStartedAtAudioTime: number | null;
   playing: boolean;
+  onPauseTransform?: (positionPx: number) => void;
 }
 
 interface PlaybackStripAnimationData {
@@ -112,6 +113,26 @@ function buildPlaybackStripKeyframes({
   }));
 }
 
+function getTranslateXFromTransform(transform: string): number | null {
+  if (!transform || transform === "none") return 0;
+
+  const matrixMatch = /^matrix\((.+)\)$/.exec(transform);
+  if (matrixMatch) {
+    const values = matrixMatch[1]!.split(",").map((value) => Number(value.trim()));
+    return Number.isFinite(values[4]) ? values[4]! : null;
+  }
+
+  const matrix3dMatch = /^matrix3d\((.+)\)$/.exec(transform);
+  if (matrix3dMatch) {
+    const values = matrix3dMatch[1]!
+      .split(",")
+      .map((value) => Number(value.trim()));
+    return Number.isFinite(values[12]) ? values[12]! : null;
+  }
+
+  return null;
+}
+
 function usePlaybackStripAnimation({
   stripRef,
   chordLayoutData,
@@ -120,6 +141,7 @@ function usePlaybackStripAnimation({
   audioContext,
   playbackStartedAtAudioTime,
   playing,
+  onPauseTransform,
 }: UsePlaybackStripAnimationArgs) {
   const animationRef = useRef<Animation | null>(null);
   const animationGenerationRef = useRef(0);
@@ -144,7 +166,17 @@ function usePlaybackStripAnimation({
 
   useLayoutEffect(() => {
     const currentAnimation = animationRef.current;
+    const animatedElement = stripRef.current;
+
     if (currentAnimation) {
+      if (!playing && animatedElement && onPauseTransform) {
+        const computedTransform = window.getComputedStyle(animatedElement).transform;
+        const translateX = getTranslateXFromTransform(computedTransform);
+        if (translateX !== null) {
+          onPauseTransform(Math.abs(translateX));
+        }
+      }
+
       currentAnimation.onfinish = null;
       currentAnimation.cancel();
       animationRef.current = null;
@@ -242,6 +274,7 @@ function usePlaybackStripAnimation({
     chordLayoutData,
     playbackStartedAtAudioTime,
     playing,
+    onPauseTransform,
     stripRef,
   ]);
 }

--- a/src/pages/dev-playback-harness.tsx
+++ b/src/pages/dev-playback-harness.tsx
@@ -1,0 +1,343 @@
+// Dev-only harness page for verifying playback chord virtualization.
+// Exercised by scripts/verifyPlaybackChordVirtualization.mjs; returns 404 in
+// production builds.
+//
+// Query params:
+// - fixture=long | realistic  (default: long)
+// - repState=split | unified  (default: split)
+// - pausedAtLoop=1            keeps playback paused (default)
+import ErrorPage from "next/error";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import PlaybackModal, {
+  type PlaybackHarnessSnapshot,
+  type PlaybackModalDevSeed,
+} from "~/components/Tab/Playback/PlaybackModal";
+import {
+  compileFullTab,
+  generateDefaultSectionProgression,
+} from "~/utils/chordCompilationHelpers";
+import { expandFullTab } from "~/utils/playbackChordCompilationHelpers";
+import {
+  useTabStore,
+  type Section,
+  type TabMeasureLine,
+  type TabNote,
+} from "~/stores/TabStore";
+
+declare global {
+  interface Window {
+    __playbackHarness?: PlaybackHarnessSnapshot & {
+      mountedChordCount: number;
+      stripTransform: string | null;
+      chordBoundingBoxes: Array<{
+        index: number;
+        left: number;
+        right: number;
+      }>;
+      refresh: () => PlaybackHarnessSnapshot | null;
+    };
+  }
+}
+
+const HARNESS_VIEWPORT_WIDTH = 1024;
+
+function note(id: string): TabNote {
+  return {
+    type: "note",
+    palmMute: "",
+    firstString: "",
+    secondString: "3",
+    thirdString: "2",
+    fourthString: "0",
+    fifthString: "",
+    sixthString: "",
+    chordEffects: "",
+    noteLength: "quarter",
+    id,
+  };
+}
+
+function measureLine(id: string): TabMeasureLine {
+  return {
+    type: "measureLine",
+    isInPalmMuteSection: false,
+    bpmAfterLine: null,
+    id,
+  };
+}
+
+function makeColumns(prefix: string, measures: number) {
+  const columns: (TabNote | TabMeasureLine)[] = [];
+  for (let m = 0; m < measures; m++) {
+    for (let n = 0; n < 8; n++) {
+      columns.push(note(`${prefix}-n-${m}-${n}`));
+    }
+    if (m < measures - 1) {
+      columns.push(measureLine(`${prefix}-ml-${m}`));
+    }
+  }
+  return columns;
+}
+
+function makeTabSection(id: string, measures: number) {
+  return {
+    id,
+    type: "tab" as const,
+    bpm: 120,
+    baseNoteLength: "quarter" as const,
+    repetitions: 1,
+    data: makeColumns(id, measures),
+  };
+}
+
+function buildFixture(fixture: string): Section[] {
+  if (fixture === "realistic") {
+    return Array.from({ length: 10 }, (_, sectionIndex) => ({
+      id: `section-${sectionIndex}`,
+      title: `Section ${sectionIndex + 1}`,
+      data: [
+        makeTabSection(`sub-${sectionIndex}-0`, 8),
+        makeTabSection(`sub-${sectionIndex}-1`, 8),
+      ],
+    }));
+  }
+
+  return Array.from({ length: 8 }, (_, sectionIndex) => ({
+    id: `long-section-${sectionIndex}`,
+    title: `Long section ${sectionIndex + 1}`,
+    data: [
+      makeTabSection(`long-sub-${sectionIndex}-0`, 16),
+      makeTabSection(`long-sub-${sectionIndex}-1`, 16),
+    ],
+  }));
+}
+
+function computeVirtualizationStartIndex(
+  scrollPositions: number[],
+  chordWidths: number[],
+  viewportWidth: number,
+) {
+  const lastChordPosition = scrollPositions[scrollPositions.length - 1] ?? 0;
+  const finalChordWidth = chordWidths[chordWidths.length - 1] ?? 0;
+
+  for (let i = scrollPositions.length - 1; i >= 0; i--) {
+    const currentPosition = scrollPositions[i] ?? 0;
+    if (
+      currentPosition + viewportWidth <=
+      lastChordPosition + finalChordWidth
+    ) {
+      return i;
+    }
+  }
+
+  return 0;
+}
+
+function buildSplitRepetitions(
+  length: number,
+  virtualizationStartIndex: number,
+): number[] {
+  const repetitions = Array.from({ length }, () => 1);
+  for (let i = 0; i < virtualizationStartIndex; i++) {
+    repetitions[i] = 2;
+  }
+  return repetitions;
+}
+
+export default function DevPlaybackHarness() {
+  const { query, isReady } = useRouter();
+  const [harnessSnapshot, setHarnessSnapshot] =
+    useState<PlaybackHarnessSnapshot | null>(null);
+
+  const {
+    setId,
+    setTabData,
+    setBpm,
+    setExpandedTabData,
+    setPlaybackMetadata,
+    setCurrentlyPlayingMetadata,
+    atomicallyUpdateAudioMetadata,
+    setVisiblePlaybackContainerWidth,
+    setShowPlaybackModal,
+    expandedTabData,
+    playbackSpeed,
+    loopDelay,
+    chords,
+    tabData,
+  } = useTabStore((state) => ({
+    setId: state.setId,
+    setTabData: state.setTabData,
+    setBpm: state.setBpm,
+    setExpandedTabData: state.setExpandedTabData,
+    setPlaybackMetadata: state.setPlaybackMetadata,
+    setCurrentlyPlayingMetadata: state.setCurrentlyPlayingMetadata,
+    atomicallyUpdateAudioMetadata: state.atomicallyUpdateAudioMetadata,
+    setVisiblePlaybackContainerWidth: state.setVisiblePlaybackContainerWidth,
+    setShowPlaybackModal: state.setShowPlaybackModal,
+    expandedTabData: state.expandedTabData,
+    playbackSpeed: state.playbackSpeed,
+    loopDelay: state.loopDelay,
+    chords: state.chords,
+    tabData: state.tabData,
+  }));
+
+  const fixture = typeof query.fixture === "string" ? query.fixture : "long";
+  const repState = typeof query.repState === "string" ? query.repState : "split";
+  const fixtureTabData = useMemo(() => buildFixture(fixture), [fixture]);
+
+  const ready = tabData[0]?.id === fixtureTabData[0]?.id && expandedTabData !== null;
+
+  useEffect(() => {
+    if (!isReady) return;
+
+    setId(1);
+    setBpm(120);
+    setVisiblePlaybackContainerWidth(HARNESS_VIEWPORT_WIDTH);
+    setShowPlaybackModal(true);
+    setTabData((draft) => {
+      draft.splice(0, draft.length, ...fixtureTabData);
+    });
+
+    const sectionProgression = generateDefaultSectionProgression(fixtureTabData);
+
+    compileFullTab({
+      tabData: fixtureTabData,
+      sectionProgression,
+      chords,
+      baselineBpm: 120,
+      playbackSpeed,
+      setCurrentlyPlayingMetadata,
+      startLoopIndex: 0,
+      endLoopIndex: -1,
+      atomicallyUpdateAudioMetadata,
+      loopDelay,
+    });
+
+    const expanded = expandFullTab({
+      tabData: fixtureTabData,
+      location: null,
+      sectionProgression,
+      chords,
+      baselineBpm: 120,
+      playbackSpeed,
+      setPlaybackMetadata,
+      startLoopIndex: 0,
+      endLoopIndex: -1,
+      visiblePlaybackContainerWidth: HARNESS_VIEWPORT_WIDTH,
+      loopDelay,
+    });
+
+    setExpandedTabData(expanded.chords);
+  }, [
+    isReady,
+    fixtureTabData,
+    setId,
+    setBpm,
+    setTabData,
+    setExpandedTabData,
+    setPlaybackMetadata,
+    setCurrentlyPlayingMetadata,
+    atomicallyUpdateAudioMetadata,
+    setVisiblePlaybackContainerWidth,
+    setShowPlaybackModal,
+    chords,
+    playbackSpeed,
+    loopDelay,
+  ]);
+
+  const devSeed = useMemo<PlaybackModalDevSeed | undefined>(() => {
+    if (!expandedTabData || expandedTabData.length === 0) return undefined;
+
+    const scrollPositions: number[] = [];
+    const chordWidths: number[] = [];
+    let offsetLeft = 0;
+
+    for (let i = 0; i < expandedTabData.length; i++) {
+      const chord = expandedTabData[i];
+      const isMeasureLine =
+        chord?.type === "tab" && chord?.data.chordData.includes("|");
+      const isSpacerChord =
+        (chord?.type === "tab" && chord?.data.chordData[0] === "-1") ||
+        (chord?.type === "strum" && chord?.data.strumIndex === -1);
+      const chordWidth = isMeasureLine
+        ? 2
+        : isSpacerChord
+          ? 16
+          : chord?.type === "tab"
+            ? 34
+            : 40;
+
+      scrollPositions[i] = offsetLeft;
+      chordWidths[i] = chordWidth;
+      offsetLeft += chordWidth;
+    }
+
+    const virtualizationStartIndex = computeVirtualizationStartIndex(
+      scrollPositions,
+      chordWidths,
+      HARNESS_VIEWPORT_WIDTH,
+    );
+
+    const chordIndex = Number(query.chordIndex ?? 0);
+    const safeChordIndex = Number.isFinite(chordIndex)
+      ? Math.min(Math.max(0, chordIndex), expandedTabData.length - 1)
+      : 0;
+
+    const repetitions =
+      repState === "split"
+        ? buildSplitRepetitions(expandedTabData.length, virtualizationStartIndex)
+        : Array.from({ length: expandedTabData.length }, () => 1);
+
+    return {
+      currentChordIndex: safeChordIndex,
+      chordRepetitions: repetitions,
+    };
+  }, [expandedTabData, repState, query.chordIndex]);
+
+  const handleDevStateSnapshot = useCallback((snapshot: PlaybackHarnessSnapshot) => {
+    setHarnessSnapshot(snapshot);
+  }, []);
+
+  useEffect(() => {
+    if (!ready || !harnessSnapshot) return;
+
+    const refresh = () => harnessSnapshot;
+
+    window.__playbackHarness = {
+      ...harnessSnapshot,
+      mountedChordCount: harnessSnapshot.mountedChordIndices.length,
+      stripTransform:
+        document
+          .querySelector<HTMLElement>("[data-playback-strip]")
+          ?.style.transform ?? null,
+      chordBoundingBoxes: harnessSnapshot.mountedChordIndices.map((index) => {
+        const element = document.querySelector<HTMLElement>(
+          `[data-testid="playback-chord-${index}"]`,
+        );
+        const rect = element?.getBoundingClientRect();
+        return {
+          index,
+          left: rect?.left ?? -1,
+          right: rect?.right ?? -1,
+        };
+      }),
+      refresh,
+    };
+  }, [ready, harnessSnapshot]);
+
+  if (process.env.NODE_ENV === "production") {
+    return <ErrorPage statusCode={404} />;
+  }
+
+  return (
+    <div id="devPlaybackHarness" data-ready={ready} className="h-dvh w-full">
+      {ready && (
+        <PlaybackModal
+          devSeed={devSeed}
+          onDevStateSnapshot={handleDevStateSnapshot}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/utils/playbackVisibleRange.test.ts
+++ b/src/utils/playbackVisibleRange.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  getPlaybackVisibleRange,
+  type PlaybackVisibleRangeLayout,
+} from "./playbackVisibleRange";
+
+const CHORD_WIDTH = 34;
+const CHORD_COUNT = 100;
+const VIEWPORT_WIDTH = 800;
+
+function buildUniformScrollPositions(count: number, chordWidth = CHORD_WIDTH) {
+  return Array.from({ length: count }, (_, index) => index * chordWidth);
+}
+
+function buildLayout(
+  scrollPositions: number[],
+  viewportWidth = VIEWPORT_WIDTH,
+): PlaybackVisibleRangeLayout {
+  const totalWidth = scrollPositions[scrollPositions.length - 1]! + CHORD_WIDTH;
+  const finalChordWidth = CHORD_WIDTH;
+  const chordCount = scrollPositions.length;
+
+  let virtualizationStartIndex = 0;
+  for (let i = chordCount - 1; i >= 0; i--) {
+    const currentPosition = scrollPositions[i]!;
+    const lastChordPosition = scrollPositions[chordCount - 1]!;
+    if (
+      currentPosition + viewportWidth <=
+      lastChordPosition + finalChordWidth
+    ) {
+      virtualizationStartIndex = i;
+      break;
+    }
+  }
+
+  let virtualizationCatchupIndex = 0;
+  for (let i = 0; i < chordCount - 1; i++) {
+    const currentPosition = scrollPositions[i]!;
+    if (currentPosition - viewportWidth * 0.5 >= 0) {
+      virtualizationCatchupIndex = i;
+      break;
+    }
+  }
+
+  return {
+    scrollPositions,
+    totalWidth,
+    virtualizationStartIndex,
+    virtualizationCatchupIndex,
+  };
+}
+
+function buildSplitRepetitions(
+  length: number,
+  virtualizationStartIndex: number,
+): number[] {
+  const repetitions = Array.from({ length }, () => 1);
+  for (let i = 0; i < virtualizationStartIndex; i++) {
+    repetitions[i] = 2;
+  }
+  return repetitions;
+}
+
+function rangeIncludesTailIndices(
+  range: { startIndex: number; endIndex: number },
+  virtualizationStartIndex: number,
+) {
+  return range.startIndex <= virtualizationStartIndex;
+}
+
+void test("unified repetitions include chords around the playhead", () => {
+  const scrollPositions = buildUniformScrollPositions(CHORD_COUNT);
+  const layout = buildLayout(scrollPositions);
+  const chordRepetitions = Array.from({ length: CHORD_COUNT }, () => 1);
+
+  const range = getPlaybackVisibleRange({
+    layout,
+    chordCount: CHORD_COUNT,
+    currentChordIndex: 50,
+    chordRepetitions,
+    visiblePlaybackContainerWidth: VIEWPORT_WIDTH,
+  });
+
+  assert.ok(range.startIndex < 50);
+  assert.ok(range.endIndex > 50);
+});
+
+void test("split repetitions at index 0 include lower-rep tail chords", () => {
+  const scrollPositions = buildUniformScrollPositions(CHORD_COUNT);
+  const layout = buildLayout(scrollPositions);
+  const chordRepetitions = buildSplitRepetitions(
+    CHORD_COUNT,
+    layout.virtualizationStartIndex,
+  );
+
+  const range = getPlaybackVisibleRange({
+    layout,
+    chordCount: CHORD_COUNT,
+    currentChordIndex: 0,
+    chordRepetitions,
+    visiblePlaybackContainerWidth: VIEWPORT_WIDTH,
+  });
+
+  assert.ok(
+    rangeIncludesTailIndices(range, layout.virtualizationStartIndex),
+    `expected tail indices to be included, got startIndex=${range.startIndex}`,
+  );
+});
+
+void test("split repetitions at catchup index behave like unified range scan", () => {
+  const scrollPositions = buildUniformScrollPositions(CHORD_COUNT);
+  const layout = buildLayout(scrollPositions);
+  const chordRepetitions = buildSplitRepetitions(
+    CHORD_COUNT,
+    layout.virtualizationStartIndex,
+  );
+
+  const catchupIndex = layout.virtualizationCatchupIndex;
+  const range = getPlaybackVisibleRange({
+    layout,
+    chordCount: CHORD_COUNT,
+    currentChordIndex: catchupIndex,
+    chordRepetitions,
+    visiblePlaybackContainerWidth: VIEWPORT_WIDTH,
+  });
+
+  assert.ok(range.startIndex <= catchupIndex);
+  assert.ok(range.endIndex >= catchupIndex);
+});

--- a/src/utils/playbackVisibleRange.ts
+++ b/src/utils/playbackVisibleRange.ts
@@ -1,0 +1,107 @@
+export const PLAYBACK_VIRTUALIZATION_BUFFER = 100;
+
+export interface PlaybackVisibleRangeLayout {
+  scrollPositions: number[];
+  totalWidth: number;
+  virtualizationStartIndex: number;
+  virtualizationCatchupIndex: number;
+}
+
+export interface PlaybackVisibleRangeInput {
+  layout: PlaybackVisibleRangeLayout;
+  chordCount: number;
+  currentChordIndex: number;
+  chordRepetitions: number[];
+  visiblePlaybackContainerWidth: number;
+  virtualizationBuffer?: number;
+}
+
+export interface PlaybackVisibleRange {
+  startIndex: number;
+  endIndex: number;
+}
+
+function getChordPosition(
+  index: number,
+  scrollPositions: number[],
+  totalWidth: number,
+  chordRepetitions: number[],
+): number {
+  return (scrollPositions[index] ?? 0) + (chordRepetitions[index] ?? 0) * totalWidth;
+}
+
+export function getPlaybackVisibleRange({
+  layout,
+  chordCount,
+  currentChordIndex,
+  chordRepetitions,
+  visiblePlaybackContainerWidth,
+  virtualizationBuffer = PLAYBACK_VIRTUALIZATION_BUFFER,
+}: PlaybackVisibleRangeInput): PlaybackVisibleRange {
+  if (
+    chordCount === 0 ||
+    visiblePlaybackContainerWidth === 0 ||
+    chordRepetitions.length === 0
+  ) {
+    return { startIndex: 0, endIndex: 0 };
+  }
+
+  const { scrollPositions, totalWidth, virtualizationStartIndex, virtualizationCatchupIndex } =
+    layout;
+
+  const currentScrollPosition = getChordPosition(
+    currentChordIndex,
+    scrollPositions,
+    totalWidth,
+    chordRepetitions,
+  );
+
+  const halfViewport = visiblePlaybackContainerWidth / 2;
+  const minVisiblePosition =
+    currentScrollPosition - halfViewport - virtualizationBuffer;
+  const maxVisiblePosition =
+    currentScrollPosition + halfViewport + virtualizationBuffer;
+
+  let startIndex = 0;
+  let endIndex = chordCount - 1;
+
+  for (let i = 0; i < chordCount; i++) {
+    const chordPosition = getChordPosition(
+      i,
+      scrollPositions,
+      totalWidth,
+      chordRepetitions,
+    );
+    if (chordPosition >= minVisiblePosition) {
+      startIndex = Math.max(0, i - 1);
+      break;
+    }
+  }
+
+  for (let i = chordCount - 1; i >= 0; i--) {
+    const chordPosition = getChordPosition(
+      i,
+      scrollPositions,
+      totalWidth,
+      chordRepetitions,
+    );
+    if (chordPosition <= maxVisiblePosition) {
+      endIndex = Math.min(chordCount - 1, i + 1);
+      break;
+    }
+  }
+
+  const repsAreSplit =
+    (chordRepetitions[0] ?? 0) !== (chordRepetitions[chordCount - 1] ?? 0);
+
+  if (repsAreSplit && currentChordIndex < virtualizationCatchupIndex) {
+    const currentRep = chordRepetitions[currentChordIndex] ?? 0;
+    for (let i = virtualizationStartIndex; i < chordCount; i++) {
+      if ((chordRepetitions[i] ?? 0) < currentRep) {
+        startIndex = Math.min(startIndex, Math.max(0, i - 1));
+      }
+    }
+  }
+
+  return { startIndex, endIndex };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes missing chords behind the playhead when playback loops and is paused at the start of the next iteration.

The root cause was a dead zone in the `chordRepetitions` split/catchup state machine: after a loop wrap to index 0, catchup virtualization cannot run yet, but `visibleRange` still culled lower-rep tail chords that should remain visible behind the playhead.

## Changes

- **`getPlaybackVisibleRange` helper** (`src/utils/playbackVisibleRange.ts`): extracted visible-range logic and extended it to include lower-rep tail chords during the post-primary, pre-catchup window
- **Pause transform snap fix** (`usePlaybackStripAnimation.ts` + `PlaybackModal.tsx`): capture WAAPI transform on pause and preserve it until the playhead index/repetition changes
- **Dev harness** (`src/pages/dev-playback-harness.tsx`): deterministic playback fixture with `window.__playbackHarness` debug API
- **Playwright verification** (`scripts/verifyPlaybackChordVirtualization.mjs`): split-rep dead zone, unified baseline, catchup window, and paused transform checks
- **Unit tests** (`src/utils/playbackVisibleRange.test.ts`)

## Verification

```bash
npx tsx --test src/utils/playbackVisibleRange.test.ts
# with dev server running:
node scripts/verifyPlaybackChordVirtualization.mjs http://localhost:3000
```

All 3 unit tests and 32 Playwright checks pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0c26c40-8497-48f2-bbec-ee19780a1a22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0c26c40-8497-48f2-bbec-ee19780a1a22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

