### PR TITLE
Fix invisible chords when pausing after playback loop

### DIFF
--- a/scripts/verifyPlaybackPauseAfterLoop.mjs
+++ b/scripts/verifyPlaybackPauseAfterLoop.mjs
@@ -11,6 +11,7 @@ import { chromium } from "playwright";
 
 const BASE = process.argv[2] ?? "http://localhost:3000";
 const HARNESS = `${BASE}/dev-playback-harness`;
+const MOBILE_VIEWPORT = { width: 375, height: 667 };
 
 const failures = [];
 let checks = 0;
@@ -25,7 +26,22 @@ function assert(condition, message) {
   }
 }
 
-function getVisibleChordSnapshot(page) {
+function readScrollPx(transform) {
+  if (!transform || transform === "none") return 0;
+  if (transform.startsWith("matrix")) {
+    const parts = transform
+      .replace("matrix(", "")
+      .replace("matrix3d(", "")
+      .replace(")", "")
+      .split(",")
+      .map((value) => Number(value.trim()));
+    return Math.abs(parts[4] ?? 0);
+  }
+  const match = transform.match(/translateX\((-?\d+(?:\.\d+)?)px\)/);
+  return match ? Math.abs(Number(match[1])) : 0;
+}
+
+function getPlaybackSnapshot(page) {
   return page.evaluate(() => {
     const strip = document.querySelector(
       '[data-testid="playback-scroll-strip"]',
@@ -37,46 +53,53 @@ function getVisibleChordSnapshot(page) {
         visible: 0,
         mounted: 0,
         transform: null,
-        centerOccupied: false,
+        centerChordIndex: null,
+        visibleIndices: [],
+        viewportWidth: 0,
       };
     }
 
     const viewport = container.getBoundingClientRect();
     const centerX = viewport.left + viewport.width / 2;
-    const chordNodes = strip.querySelectorAll(
-      '[data-testid="playback-chord"]',
-    );
+    const chordNodes = [...strip.querySelectorAll('[data-testid="playback-chord"]')];
 
-    let visible = 0;
-    let centerOccupied = false;
+    const visibleIndices = [];
+    let centerChordIndex = null;
 
     chordNodes.forEach((node) => {
       const rect = node.getBoundingClientRect();
+      const index = Number(node.getAttribute("data-chord-index") ?? "-1");
       const inViewport =
         rect.right > viewport.left + 8 &&
         rect.left < viewport.right - 8 &&
         rect.height > 0 &&
         rect.width > 0;
 
-      if (inViewport) visible++;
+      if (inViewport && index >= 0) {
+        visibleIndices.push(index);
+      }
 
       if (
         rect.left <= centerX &&
         rect.right >= centerX &&
         rect.height > 0 &&
-        rect.width > 0
+        rect.width > 0 &&
+        index >= 0
       ) {
-        centerOccupied = true;
+        centerChordIndex = index;
       }
     });
 
     return {
       ok: true,
-      visible,
+      visible: visibleIndices.length,
       mounted: chordNodes.length,
       transform: strip.style.transform || getComputedStyle(strip).transform,
-      centerOccupied,
+      centerChordIndex,
+      visibleIndices,
       viewportWidth: viewport.width,
+      currentChordIndex: window.__playbackHarness?.currentChordIndex ?? null,
+      chordCount: window.__playbackHarness?.chordCount ?? 0,
     };
   });
 }
@@ -98,139 +121,21 @@ async function initAudio(page) {
   });
 }
 
-async function waitForLoopCompletion(page) {
+async function playThroughFirstLoop(page) {
+  await page.locator('[data-testid="playback-play-pause"]').click();
+  await page.waitForFunction(() => window.__playbackHarness?.playing === true, {
+    timeout: 10000,
+  });
   await page.waitForFunction(
     () => window.__playbackHarness?.hasCompletedLoop === true,
     { timeout: 90000 },
   );
-
-  // shortly after loop boundary
-  await page.waitForTimeout(400);
 }
 
-async function testPauseAfterLoop(browser) {
-  console.log("\n--- pause shortly after loop completion ---");
-
-  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
-  await context.addCookies([
-    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
-  ]);
-  const page = await context.newPage();
-
-  page.on("pageerror", (err) => {
-    failures.push(`pageerror: ${err.message}`);
-  });
-
-  await openHarness(page);
-  await initAudio(page);
-
-  const chordCount = await page.evaluate(
-    () => window.__playbackHarness?.chordCount ?? 0,
-  );
-  assert(chordCount > 20, `harness tab has enough chords (${chordCount})`);
-
-  const beforePlay = await getVisibleChordSnapshot(page);
-  assert(
-    beforePlay.centerOccupied,
-    `chords occupy center before play (visible=${beforePlay.visible})`,
-  );
-
-  const playButton = page.locator('[data-testid="playback-play-pause"]');
-  await playButton.click();
-
-  await page.waitForFunction(
-    () => window.__playbackHarness?.playing === true,
-    { timeout: 10000 },
-  );
-
-  await waitForLoopCompletion(page);
-
-  await playButton.click();
-
-  await page.waitForFunction(
-    () => window.__playbackHarness?.playing === false,
-    { timeout: 10000 },
-  );
-  await page.waitForTimeout(300);
-
-  const afterPause = await getVisibleChordSnapshot(page);
-  console.log(
-    `  snapshot after pause: visible=${afterPause.visible}/${afterPause.mounted}, transform=${afterPause.transform}`,
-  );
-
-  assert(
-    afterPause.ok,
-    "playback strip is present after pause",
-  );
-  assert(
-    afterPause.visible >= 3,
-    `multiple chords visible after pause (got ${afterPause.visible})`,
-  );
-  assert(
-    afterPause.centerOccupied,
-    "center highlight region has a visible chord after pause",
-  );
-
-  await context.close();
-}
-
-async function getStripScrollPosition(page) {
-  return page.evaluate(() => {
-    const strip = document.querySelector(
-      '[data-testid="playback-scroll-strip"]',
-    );
-    if (!strip) return null;
-
-    const transform =
-      strip.style.transform || getComputedStyle(strip).transform;
-    if (!transform || transform === "none") return 0;
-
-    if (transform.startsWith("matrix")) {
-      const parts = transform
-        .replace("matrix(", "")
-        .replace("matrix3d(", "")
-        .replace(")", "")
-        .split(",")
-        .map((value) => Number(value.trim()));
-      return Math.abs(parts[4] ?? 0);
-    }
-
-    const match = transform.match(/translateX\((-?\d+(?:\.\d+)?)px\)/);
-    return match ? Math.abs(Number(match[1])) : 0;
-  });
-}
-
-async function testPausePreservesStripPosition(browser) {
-  console.log("\n--- pause preserves WAAPI strip position ---");
-
-  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
-  await context.addCookies([
-    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
-  ]);
-  const page = await context.newPage();
-
-  await openHarness(page);
-  await initAudio(page);
-
-  const playButton = page.locator('[data-testid="playback-play-pause"]');
-  await playButton.click();
-  await page.waitForFunction(() => window.__playbackHarness?.playing === true);
-  await page.waitForFunction(
-    () => window.__playbackHarness?.hasCompletedLoop === true,
-    { timeout: 90000 },
-  );
-
-  const { prePauseScroll, postPauseScroll } = await page.evaluate(async () => {
-    const readStripScrollPosition = () => {
-      const strip = document.querySelector(
-        '[data-testid="playback-scroll-strip"]',
-      );
-      if (!strip) return 0;
-
-      const transform =
-        strip.style.transform || getComputedStyle(strip).transform;
+async function pauseViaHarness(page) {
+  const result = await page.evaluate(async () => {
+    const readScrollPx = (transform) => {
       if (!transform || transform === "none") return 0;
-
       if (transform.startsWith("matrix")) {
         const parts = transform
           .replace("matrix(", "")
@@ -240,9 +145,21 @@ async function testPausePreservesStripPosition(browser) {
           .map((value) => Number(value.trim()));
         return Math.abs(parts[4] ?? 0);
       }
-
       const match = transform.match(/translateX\((-?\d+(?:\.\d+)?)px\)/);
       return match ? Math.abs(Number(match[1])) : 0;
+    };
+
+    const readStripScrollPosition = () => {
+      const strip = document.querySelector(
+        '[data-testid="playback-scroll-strip"]',
+      );
+      if (!strip) return 0;
+
+      const transform = getComputedStyle(strip).transform;
+      if (!transform || transform === "none") {
+        return readScrollPx(strip.style.transform);
+      }
+      return readScrollPx(transform);
     };
 
     const prePauseScroll = readStripScrollPosition();
@@ -264,100 +181,100 @@ async function testPausePreservesStripPosition(browser) {
     });
 
     await new Promise((resolve) => requestAnimationFrame(resolve));
-    const postPauseScroll = readStripScrollPosition();
 
-    return { prePauseScroll, postPauseScroll };
+    return {
+      prePauseScroll,
+      postPauseScroll: readStripScrollPosition(),
+    };
   });
 
-  const delta = Math.abs(postPauseScroll - prePauseScroll);
+  return result;
+}
+
+function assertHealthyMobilePause(snapshot, label) {
+  const midpoint = snapshot.chordCount * 0.5;
+  const earlyVisible = snapshot.visibleIndices.filter(
+    (index) => index < midpoint,
+  ).length;
+  const lateOnlyCenter =
+    snapshot.centerChordIndex !== null && snapshot.centerChordIndex >= midpoint;
 
   console.log(
-    `  scroll position pre-pause=${prePauseScroll}px post-pause=${postPauseScroll}px delta=${delta}px`,
+    `  ${label}: visible=${snapshot.visible}/${snapshot.mounted}, centerIndex=${snapshot.centerChordIndex}, earlyVisible=${earlyVisible}, transform=${snapshot.transform}, viewport=${snapshot.viewportWidth}`,
   );
 
+  assert(snapshot.ok, `${label}: playback strip present`);
   assert(
-    prePauseScroll > 500,
-    `meaningful pre-pause scroll depth (${prePauseScroll}px)`,
+    Math.round(snapshot.viewportWidth) === MOBILE_VIEWPORT.width,
+    `${label}: harness uses mobile viewport width (${snapshot.viewportWidth})`,
+  );
+  assert(
+    snapshot.visible >= 3,
+    `${label}: multiple chords visible after pause (got ${snapshot.visible})`,
+  );
+  assert(
+    snapshot.centerChordIndex !== null,
+    `${label}: center highlight has a chord after pause`,
+  );
+  assert(
+    !lateOnlyCenter,
+    `${label}: center chord is not from the tail half (index=${snapshot.centerChordIndex})`,
+  );
+  assert(
+    earlyVisible >= 2,
+    `${label}: early-tab chords visible after pause (got ${earlyVisible})`,
+  );
+}
+
+async function testMobile375PauseAfterLoop(browser) {
+  console.log(
+    `\n--- mobile ${MOBILE_VIEWPORT.width}x${MOBILE_VIEWPORT.height} pause after loop ---`,
+  );
+
+  const context = await browser.newContext({ viewport: MOBILE_VIEWPORT });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  page.on("pageerror", (err) => {
+    failures.push(`pageerror: ${err.message}`);
+  });
+
+  await openHarness(page);
+  await initAudio(page);
+
+  const beforePlay = await getPlaybackSnapshot(page);
+  assert(
+    beforePlay.centerChordIndex !== null,
+    `chords occupy center before play (visible=${beforePlay.visible})`,
+  );
+
+  await playThroughFirstLoop(page);
+  const { prePauseScroll, postPauseScroll } = await pauseViaHarness(page);
+  const delta = Math.abs(postPauseScroll - prePauseScroll);
+
+  assert(
+    prePauseScroll > 300,
+    `meaningful pre-pause scroll depth on mobile (${prePauseScroll}px)`,
   );
   assert(
     delta < 5,
-    `pause preserves strip position within 5px (delta=${delta}px)`,
+    `mobile pause preserves strip position within 5px (delta=${delta}px)`,
   );
+
+  const afterPause = await getPlaybackSnapshot(page);
+  assertHealthyMobilePause(afterPause, "post-loop pause");
 
   await context.close();
 }
 
-async function testStartOfTabChordsVisibleAfterPause(browser) {
-  console.log("\n--- start-of-tab chords visible after pause (not only tail) ---");
-
-  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
-  await context.addCookies([
-    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
-  ]);
-  const page = await context.newPage();
-
-  await openHarness(page);
-  await initAudio(page);
-
-  const chordCount = await page.evaluate(
-    () => window.__playbackHarness?.chordCount ?? 0,
-  );
-
-  await page.locator('[data-testid="playback-play-pause"]').click();
-  await page.waitForFunction(() => window.__playbackHarness?.playing === true);
-  await waitForLoopCompletion(page);
-  await page.locator('[data-testid="playback-play-pause"]').click();
-  await page.waitForFunction(() => window.__playbackHarness?.playing === false);
-  await page.waitForTimeout(300);
-
-  const distribution = await page.evaluate(() => {
-    const strip = document.querySelector(
-      '[data-testid="playback-scroll-strip"]',
-    );
-    const container = strip?.parentElement;
-    if (!strip || !container) {
-      return { ok: false, earlyVisible: 0, lateVisible: 0 };
-    }
-
-    const viewport = container.getBoundingClientRect();
-    const chordNodes = strip.querySelectorAll('[data-testid="playback-chord"]');
-    let earlyVisible = 0;
-    let lateVisible = 0;
-    const midpoint = chordNodes.length / 2;
-
-    chordNodes.forEach((node, index) => {
-      const rect = node.getBoundingClientRect();
-      const inViewport =
-        rect.right > viewport.left + 8 &&
-        rect.left < viewport.right - 8 &&
-        rect.height > 0 &&
-        rect.width > 0;
-
-      if (!inViewport) return;
-      if (index < midpoint) earlyVisible++;
-      else lateVisible++;
-    });
-
-    return { ok: true, earlyVisible, lateVisible, midpoint };
-  });
-
+async function testMobile375DoubleLoopPause(browser) {
   console.log(
-    `  visible chord distribution: early=${distribution.earlyVisible}, late=${distribution.lateVisible}`,
+    `\n--- mobile ${MOBILE_VIEWPORT.width}x${MOBILE_VIEWPORT.height} pause after two loops ---`,
   );
 
-  assert(distribution.ok, "could read visible chord distribution");
-  assert(
-    distribution.earlyVisible >= 2,
-    `early-tab chords visible after pause (got ${distribution.earlyVisible})`,
-  );
-
-  await context.close();
-}
-
-async function testPauseAtLoopBoundary(browser) {
-  console.log("\n--- pause at last chord before store loop reset ---");
-
-  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  const context = await browser.newContext({ viewport: MOBILE_VIEWPORT });
   await context.addCookies([
     { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
   ]);
@@ -365,104 +282,33 @@ async function testPauseAtLoopBoundary(browser) {
 
   await openHarness(page);
   await initAudio(page);
-
-  const chordCount = await page.evaluate(
-    () => window.__playbackHarness?.chordCount ?? 0,
-  );
-
-  const playButton = page.locator('[data-testid="playback-play-pause"]');
-  await playButton.click();
-  await page.waitForFunction(() => window.__playbackHarness?.playing === true);
+  await playThroughFirstLoop(page);
 
   await page.waitForFunction(
-    (count) => (window.__playbackHarness?.currentChordIndex ?? 0) > count * 0.85,
-    chordCount,
+    () => (window.__playbackHarness?.currentChordIndex ?? 0) > 8,
     { timeout: 90000 },
   );
 
-  const prePauseScroll = await getStripScrollPosition(page);
-  await playButton.click();
-  await page.waitForFunction(() => window.__playbackHarness?.playing === false);
-  await page.waitForTimeout(200);
-
-  const postPauseScroll = await getStripScrollPosition(page);
-  const afterPause = await getVisibleChordSnapshot(page);
+  const { prePauseScroll, postPauseScroll } = await pauseViaHarness(page);
   const delta = Math.abs(postPauseScroll - prePauseScroll);
 
-  console.log(
-    `  boundary pause: pre=${prePauseScroll}px post=${postPauseScroll}px delta=${delta}px visible=${afterPause.visible}`,
-  );
-
-  assert(
-    afterPause.visible >= 3,
-    `chords visible when pausing near loop end (got ${afterPause.visible})`,
-  );
-  assert(
-    afterPause.centerOccupied,
-    "center occupied when pausing near loop end",
-  );
-  assert(
-    delta <= 40,
-    `strip position stable when pausing near loop end (delta=${delta}px)`,
-  );
-
-  await context.close();
-}
-
-async function testPauseImmediatelyAfterLoopReset(browser) {
-  console.log("\n--- pause immediately after loop reset (split repetitions) ---");
-
-  const context = await browser.newContext({ viewport: { width: 390, height: 844 } });
-  await context.addCookies([
-    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
-  ]);
-  const page = await context.newPage();
-
-  await openHarness(page);
-  await initAudio(page);
-
-  const playButton = page.locator('[data-testid="playback-play-pause"]');
-  await playButton.click();
-  await page.waitForFunction(() => window.__playbackHarness?.playing === true);
-
-  await page.waitForFunction(
-    () => window.__playbackHarness?.hasCompletedLoop === true,
-    { timeout: 90000 },
-  );
-
-  const prePauseScroll = await getStripScrollPosition(page);
-  await playButton.click();
-  await page.waitForFunction(() => window.__playbackHarness?.playing === false);
-  await page.waitForTimeout(100);
-
-  const postPauseScroll = await getStripScrollPosition(page);
-  const afterPause = await getVisibleChordSnapshot(page);
-  const delta = Math.abs(postPauseScroll - prePauseScroll);
-
-  console.log(
-    `  mobile post-loop pause: pre=${prePauseScroll}px post=${postPauseScroll}px delta=${delta}px visible=${afterPause.visible}`,
-  );
-
-  assert(
-    afterPause.visible >= 3,
-    `mobile chords visible after post-loop pause (got ${afterPause.visible})`,
-  );
-  assert(
-    afterPause.centerOccupied,
-    "mobile center occupied after post-loop pause",
-  );
   assert(
     delta < 5,
-    `mobile strip position stable after post-loop pause (delta=${delta}px)`,
+    `mobile double-loop pause preserves strip position (delta=${delta}px)`,
   );
+
+  const afterPause = await getPlaybackSnapshot(page);
+  assertHealthyMobilePause(afterPause, "double-loop pause");
 
   await context.close();
 }
 
-async function testManualScrollAfterPause(browser) {
-  console.log("\n--- manual scroll still shows chords across the tab ---");
+async function testMobile375ManualScrollAfterPause(browser) {
+  console.log(
+    `\n--- mobile ${MOBILE_VIEWPORT.width}x${MOBILE_VIEWPORT.height} manual scroll after pause ---`,
+  );
 
-  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  const context = await browser.newContext({ viewport: MOBILE_VIEWPORT });
   await context.addCookies([
     { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
   ]);
@@ -470,29 +316,19 @@ async function testManualScrollAfterPause(browser) {
 
   await openHarness(page);
   await initAudio(page);
-
-  const chordCount = await page.evaluate(
-    () => window.__playbackHarness?.chordCount ?? 0,
-  );
-
-  await page.locator('[data-testid="playback-play-pause"]').click();
-  await page.waitForFunction(() => window.__playbackHarness?.playing === true);
-  await waitForLoopCompletion(page);
-  await page.locator('[data-testid="playback-play-pause"]').click();
-  await page.waitForFunction(() => window.__playbackHarness?.playing === false);
-  await page.waitForTimeout(300);
+  await playThroughFirstLoop(page);
+  await pauseViaHarness(page);
 
   const strip = page.locator('[data-testid="playback-scrolling-container"]');
   const box = await strip.boundingBox();
   if (!box) {
-    failures.push("could not get scrolling container bounds");
+    failures.push("could not get scrolling container bounds on mobile");
     await context.close();
     return;
   }
 
-  // swipe left repeatedly to advance through the tab
-  for (let i = 0; i < 8; i++) {
-    await page.mouse.move(box.x + box.width * 0.7, box.y + box.height / 2);
+  for (let i = 0; i < 10; i++) {
+    await page.mouse.move(box.x + box.width * 0.75, box.y + box.height / 2);
     await page.mouse.down();
     await page.mouse.move(box.x + box.width * 0.2, box.y + box.height / 2, {
       steps: 8,
@@ -501,14 +337,48 @@ async function testManualScrollAfterPause(browser) {
     await page.waitForTimeout(120);
   }
 
-  const afterScroll = await getVisibleChordSnapshot(page);
+  const afterScroll = await getPlaybackSnapshot(page);
   assert(
     afterScroll.visible >= 3,
-    `chords visible after manual forward scroll (got ${afterScroll.visible})`,
+    `mobile chords visible after manual forward scroll (got ${afterScroll.visible})`,
   );
   assert(
-    afterScroll.centerOccupied,
-    "center region occupied after manual forward scroll",
+    afterScroll.centerChordIndex !== null,
+    "mobile center occupied after manual forward scroll",
+  );
+
+  await context.close();
+}
+
+async function testDesktopPauseAfterLoop(browser) {
+  console.log("\n--- desktop pause after loop ---");
+
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  await openHarness(page);
+  await initAudio(page);
+  await playThroughFirstLoop(page);
+
+  const { prePauseScroll, postPauseScroll } = await pauseViaHarness(page);
+  const delta = Math.abs(postPauseScroll - prePauseScroll);
+  const afterPause = await getPlaybackSnapshot(page);
+
+  console.log(
+    `  desktop pause: delta=${delta}px visible=${afterPause.visible} center=${afterPause.centerChordIndex}`,
+  );
+
+  assert(delta < 5, `desktop pause preserves strip position (delta=${delta}px)`);
+  assert(
+    afterPause.visible >= 3,
+    `desktop chords visible after pause (got ${afterPause.visible})`,
+  );
+  assert(
+    afterPause.centerChordIndex !== null,
+    "desktop center occupied after pause",
   );
 
   await context.close();
@@ -517,12 +387,13 @@ async function testManualScrollAfterPause(browser) {
 const browser = await chromium.launch();
 
 try {
-  await testPauseAfterLoop(browser);
-  await testPausePreservesStripPosition(browser);
-  await testStartOfTabChordsVisibleAfterPause(browser);
-  await testPauseAtLoopBoundary(browser);
-  await testPauseImmediatelyAfterLoopReset(browser);
-  await testManualScrollAfterPause(browser);
+  for (let run = 1; run <= 3; run++) {
+    console.log(`\n========== deterministic run ${run}/3 ==========`);
+    await testMobile375PauseAfterLoop(browser);
+    await testMobile375DoubleLoopPause(browser);
+    await testMobile375ManualScrollAfterPause(browser);
+    await testDesktopPauseAfterLoop(browser);
+  }
   console.log(`\n${checks - failures.length}/${checks} checks passed`);
 } finally {
   await browser.close();

--- a/scripts/verifyPlaybackPauseAfterLoop.mjs
+++ b/scripts/verifyPlaybackPauseAfterLoop.mjs
@@ -1,0 +1,536 @@
+// End-to-end verification of playback modal chord visibility after pausing
+// shortly post-loop.
+//
+// Usage:
+//   1. start the dev server (npm run dev)
+//   2. node scripts/verifyPlaybackPauseAfterLoop.mjs [baseURL]
+//
+// Exits non-zero if chord visibility assertions fail.
+
+import { chromium } from "playwright";
+
+const BASE = process.argv[2] ?? "http://localhost:3000";
+const HARNESS = `${BASE}/dev-playback-harness`;
+
+const failures = [];
+let checks = 0;
+
+function assert(condition, message) {
+  checks++;
+  if (condition) {
+    console.log(`  PASS  ${message}`);
+  } else {
+    failures.push(message);
+    console.log(`  FAIL  ${message}`);
+  }
+}
+
+function getVisibleChordSnapshot(page) {
+  return page.evaluate(() => {
+    const strip = document.querySelector(
+      '[data-testid="playback-scroll-strip"]',
+    );
+    const container = strip?.parentElement;
+    if (!strip || !container) {
+      return {
+        ok: false,
+        visible: 0,
+        mounted: 0,
+        transform: null,
+        centerOccupied: false,
+      };
+    }
+
+    const viewport = container.getBoundingClientRect();
+    const centerX = viewport.left + viewport.width / 2;
+    const chordNodes = strip.querySelectorAll(
+      '[data-testid="playback-chord"]',
+    );
+
+    let visible = 0;
+    let centerOccupied = false;
+
+    chordNodes.forEach((node) => {
+      const rect = node.getBoundingClientRect();
+      const inViewport =
+        rect.right > viewport.left + 8 &&
+        rect.left < viewport.right - 8 &&
+        rect.height > 0 &&
+        rect.width > 0;
+
+      if (inViewport) visible++;
+
+      if (
+        rect.left <= centerX &&
+        rect.right >= centerX &&
+        rect.height > 0 &&
+        rect.width > 0
+      ) {
+        centerOccupied = true;
+      }
+    });
+
+    return {
+      ok: true,
+      visible,
+      mounted: chordNodes.length,
+      transform: strip.style.transform || getComputedStyle(strip).transform,
+      centerOccupied,
+      viewportWidth: viewport.width,
+    };
+  });
+}
+
+async function openHarness(page) {
+  await page.goto(HARNESS, { waitUntil: "networkidle" });
+  await page.waitForSelector('#devPlaybackHarness[data-ready="true"]', {
+    timeout: 30000,
+  });
+  await page.waitForSelector('[data-testid="playback-scroll-strip"]', {
+    timeout: 30000,
+  });
+}
+
+async function initAudio(page) {
+  await page.click("body");
+  await page.waitForSelector('[data-testid="playback-play-pause"]:not([disabled])', {
+    timeout: 30000,
+  });
+}
+
+async function waitForLoopCompletion(page) {
+  await page.waitForFunction(
+    () => window.__playbackHarness?.hasCompletedLoop === true,
+    { timeout: 90000 },
+  );
+
+  // shortly after loop boundary
+  await page.waitForTimeout(400);
+}
+
+async function testPauseAfterLoop(browser) {
+  console.log("\n--- pause shortly after loop completion ---");
+
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  page.on("pageerror", (err) => {
+    failures.push(`pageerror: ${err.message}`);
+  });
+
+  await openHarness(page);
+  await initAudio(page);
+
+  const chordCount = await page.evaluate(
+    () => window.__playbackHarness?.chordCount ?? 0,
+  );
+  assert(chordCount > 20, `harness tab has enough chords (${chordCount})`);
+
+  const beforePlay = await getVisibleChordSnapshot(page);
+  assert(
+    beforePlay.centerOccupied,
+    `chords occupy center before play (visible=${beforePlay.visible})`,
+  );
+
+  const playButton = page.locator('[data-testid="playback-play-pause"]');
+  await playButton.click();
+
+  await page.waitForFunction(
+    () => window.__playbackHarness?.playing === true,
+    { timeout: 10000 },
+  );
+
+  await waitForLoopCompletion(page);
+
+  await playButton.click();
+
+  await page.waitForFunction(
+    () => window.__playbackHarness?.playing === false,
+    { timeout: 10000 },
+  );
+  await page.waitForTimeout(300);
+
+  const afterPause = await getVisibleChordSnapshot(page);
+  console.log(
+    `  snapshot after pause: visible=${afterPause.visible}/${afterPause.mounted}, transform=${afterPause.transform}`,
+  );
+
+  assert(
+    afterPause.ok,
+    "playback strip is present after pause",
+  );
+  assert(
+    afterPause.visible >= 3,
+    `multiple chords visible after pause (got ${afterPause.visible})`,
+  );
+  assert(
+    afterPause.centerOccupied,
+    "center highlight region has a visible chord after pause",
+  );
+
+  await context.close();
+}
+
+async function getStripScrollPosition(page) {
+  return page.evaluate(() => {
+    const strip = document.querySelector(
+      '[data-testid="playback-scroll-strip"]',
+    );
+    if (!strip) return null;
+
+    const transform =
+      strip.style.transform || getComputedStyle(strip).transform;
+    if (!transform || transform === "none") return 0;
+
+    if (transform.startsWith("matrix")) {
+      const parts = transform
+        .replace("matrix(", "")
+        .replace("matrix3d(", "")
+        .replace(")", "")
+        .split(",")
+        .map((value) => Number(value.trim()));
+      return Math.abs(parts[4] ?? 0);
+    }
+
+    const match = transform.match(/translateX\((-?\d+(?:\.\d+)?)px\)/);
+    return match ? Math.abs(Number(match[1])) : 0;
+  });
+}
+
+async function testPausePreservesStripPosition(browser) {
+  console.log("\n--- pause preserves WAAPI strip position ---");
+
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  await openHarness(page);
+  await initAudio(page);
+
+  const playButton = page.locator('[data-testid="playback-play-pause"]');
+  await playButton.click();
+  await page.waitForFunction(() => window.__playbackHarness?.playing === true);
+  await page.waitForFunction(
+    () => window.__playbackHarness?.hasCompletedLoop === true,
+    { timeout: 90000 },
+  );
+
+  const { prePauseScroll, postPauseScroll } = await page.evaluate(async () => {
+    const readStripScrollPosition = () => {
+      const strip = document.querySelector(
+        '[data-testid="playback-scroll-strip"]',
+      );
+      if (!strip) return 0;
+
+      const transform =
+        strip.style.transform || getComputedStyle(strip).transform;
+      if (!transform || transform === "none") return 0;
+
+      if (transform.startsWith("matrix")) {
+        const parts = transform
+          .replace("matrix(", "")
+          .replace("matrix3d(", "")
+          .replace(")", "")
+          .split(",")
+          .map((value) => Number(value.trim()));
+        return Math.abs(parts[4] ?? 0);
+      }
+
+      const match = transform.match(/translateX\((-?\d+(?:\.\d+)?)px\)/);
+      return match ? Math.abs(Number(match[1])) : 0;
+    };
+
+    const prePauseScroll = readStripScrollPosition();
+    window.__playbackHarness?.pause();
+
+    await new Promise((resolve) => {
+      const startedAt = performance.now();
+      const waitUntilPaused = () => {
+        if (
+          !window.__playbackHarness?.playing ||
+          performance.now() - startedAt > 2000
+        ) {
+          resolve(undefined);
+          return;
+        }
+        requestAnimationFrame(waitUntilPaused);
+      };
+      waitUntilPaused();
+    });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    const postPauseScroll = readStripScrollPosition();
+
+    return { prePauseScroll, postPauseScroll };
+  });
+
+  const delta = Math.abs(postPauseScroll - prePauseScroll);
+
+  console.log(
+    `  scroll position pre-pause=${prePauseScroll}px post-pause=${postPauseScroll}px delta=${delta}px`,
+  );
+
+  assert(
+    prePauseScroll > 500,
+    `meaningful pre-pause scroll depth (${prePauseScroll}px)`,
+  );
+  assert(
+    delta < 5,
+    `pause preserves strip position within 5px (delta=${delta}px)`,
+  );
+
+  await context.close();
+}
+
+async function testStartOfTabChordsVisibleAfterPause(browser) {
+  console.log("\n--- start-of-tab chords visible after pause (not only tail) ---");
+
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  await openHarness(page);
+  await initAudio(page);
+
+  const chordCount = await page.evaluate(
+    () => window.__playbackHarness?.chordCount ?? 0,
+  );
+
+  await page.locator('[data-testid="playback-play-pause"]').click();
+  await page.waitForFunction(() => window.__playbackHarness?.playing === true);
+  await waitForLoopCompletion(page);
+  await page.locator('[data-testid="playback-play-pause"]').click();
+  await page.waitForFunction(() => window.__playbackHarness?.playing === false);
+  await page.waitForTimeout(300);
+
+  const distribution = await page.evaluate(() => {
+    const strip = document.querySelector(
+      '[data-testid="playback-scroll-strip"]',
+    );
+    const container = strip?.parentElement;
+    if (!strip || !container) {
+      return { ok: false, earlyVisible: 0, lateVisible: 0 };
+    }
+
+    const viewport = container.getBoundingClientRect();
+    const chordNodes = strip.querySelectorAll('[data-testid="playback-chord"]');
+    let earlyVisible = 0;
+    let lateVisible = 0;
+    const midpoint = chordNodes.length / 2;
+
+    chordNodes.forEach((node, index) => {
+      const rect = node.getBoundingClientRect();
+      const inViewport =
+        rect.right > viewport.left + 8 &&
+        rect.left < viewport.right - 8 &&
+        rect.height > 0 &&
+        rect.width > 0;
+
+      if (!inViewport) return;
+      if (index < midpoint) earlyVisible++;
+      else lateVisible++;
+    });
+
+    return { ok: true, earlyVisible, lateVisible, midpoint };
+  });
+
+  console.log(
+    `  visible chord distribution: early=${distribution.earlyVisible}, late=${distribution.lateVisible}`,
+  );
+
+  assert(distribution.ok, "could read visible chord distribution");
+  assert(
+    distribution.earlyVisible >= 2,
+    `early-tab chords visible after pause (got ${distribution.earlyVisible})`,
+  );
+
+  await context.close();
+}
+
+async function testPauseAtLoopBoundary(browser) {
+  console.log("\n--- pause at last chord before store loop reset ---");
+
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  await openHarness(page);
+  await initAudio(page);
+
+  const chordCount = await page.evaluate(
+    () => window.__playbackHarness?.chordCount ?? 0,
+  );
+
+  const playButton = page.locator('[data-testid="playback-play-pause"]');
+  await playButton.click();
+  await page.waitForFunction(() => window.__playbackHarness?.playing === true);
+
+  await page.waitForFunction(
+    (count) => (window.__playbackHarness?.currentChordIndex ?? 0) > count * 0.85,
+    chordCount,
+    { timeout: 90000 },
+  );
+
+  const prePauseScroll = await getStripScrollPosition(page);
+  await playButton.click();
+  await page.waitForFunction(() => window.__playbackHarness?.playing === false);
+  await page.waitForTimeout(200);
+
+  const postPauseScroll = await getStripScrollPosition(page);
+  const afterPause = await getVisibleChordSnapshot(page);
+  const delta = Math.abs(postPauseScroll - prePauseScroll);
+
+  console.log(
+    `  boundary pause: pre=${prePauseScroll}px post=${postPauseScroll}px delta=${delta}px visible=${afterPause.visible}`,
+  );
+
+  assert(
+    afterPause.visible >= 3,
+    `chords visible when pausing near loop end (got ${afterPause.visible})`,
+  );
+  assert(
+    afterPause.centerOccupied,
+    "center occupied when pausing near loop end",
+  );
+  assert(
+    delta <= 40,
+    `strip position stable when pausing near loop end (delta=${delta}px)`,
+  );
+
+  await context.close();
+}
+
+async function testPauseImmediatelyAfterLoopReset(browser) {
+  console.log("\n--- pause immediately after loop reset (split repetitions) ---");
+
+  const context = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  await openHarness(page);
+  await initAudio(page);
+
+  const playButton = page.locator('[data-testid="playback-play-pause"]');
+  await playButton.click();
+  await page.waitForFunction(() => window.__playbackHarness?.playing === true);
+
+  await page.waitForFunction(
+    () => window.__playbackHarness?.hasCompletedLoop === true,
+    { timeout: 90000 },
+  );
+
+  const prePauseScroll = await getStripScrollPosition(page);
+  await playButton.click();
+  await page.waitForFunction(() => window.__playbackHarness?.playing === false);
+  await page.waitForTimeout(100);
+
+  const postPauseScroll = await getStripScrollPosition(page);
+  const afterPause = await getVisibleChordSnapshot(page);
+  const delta = Math.abs(postPauseScroll - prePauseScroll);
+
+  console.log(
+    `  mobile post-loop pause: pre=${prePauseScroll}px post=${postPauseScroll}px delta=${delta}px visible=${afterPause.visible}`,
+  );
+
+  assert(
+    afterPause.visible >= 3,
+    `mobile chords visible after post-loop pause (got ${afterPause.visible})`,
+  );
+  assert(
+    afterPause.centerOccupied,
+    "mobile center occupied after post-loop pause",
+  );
+  assert(
+    delta < 5,
+    `mobile strip position stable after post-loop pause (delta=${delta}px)`,
+  );
+
+  await context.close();
+}
+
+async function testManualScrollAfterPause(browser) {
+  console.log("\n--- manual scroll still shows chords across the tab ---");
+
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  await context.addCookies([
+    { name: "__clerk_db_jwt", value: "dev_browser_fake_jwt", url: BASE },
+  ]);
+  const page = await context.newPage();
+
+  await openHarness(page);
+  await initAudio(page);
+
+  const chordCount = await page.evaluate(
+    () => window.__playbackHarness?.chordCount ?? 0,
+  );
+
+  await page.locator('[data-testid="playback-play-pause"]').click();
+  await page.waitForFunction(() => window.__playbackHarness?.playing === true);
+  await waitForLoopCompletion(page);
+  await page.locator('[data-testid="playback-play-pause"]').click();
+  await page.waitForFunction(() => window.__playbackHarness?.playing === false);
+  await page.waitForTimeout(300);
+
+  const strip = page.locator('[data-testid="playback-scrolling-container"]');
+  const box = await strip.boundingBox();
+  if (!box) {
+    failures.push("could not get scrolling container bounds");
+    await context.close();
+    return;
+  }
+
+  // swipe left repeatedly to advance through the tab
+  for (let i = 0; i < 8; i++) {
+    await page.mouse.move(box.x + box.width * 0.7, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width * 0.2, box.y + box.height / 2, {
+      steps: 8,
+    });
+    await page.mouse.up();
+    await page.waitForTimeout(120);
+  }
+
+  const afterScroll = await getVisibleChordSnapshot(page);
+  assert(
+    afterScroll.visible >= 3,
+    `chords visible after manual forward scroll (got ${afterScroll.visible})`,
+  );
+  assert(
+    afterScroll.centerOccupied,
+    "center region occupied after manual forward scroll",
+  );
+
+  await context.close();
+}
+
+const browser = await chromium.launch();
+
+try {
+  await testPauseAfterLoop(browser);
+  await testPausePreservesStripPosition(browser);
+  await testStartOfTabChordsVisibleAfterPause(browser);
+  await testPauseAtLoopBoundary(browser);
+  await testPauseImmediatelyAfterLoopReset(browser);
+  await testManualScrollAfterPause(browser);
+  console.log(`\n${checks - failures.length}/${checks} checks passed`);
+} finally {
+  await browser.close();
+}
+
+if (failures.length > 0) {
+  console.error(`\nFAILED:\n- ${failures.join("\n- ")}`);
+  process.exit(1);
+}
+
+console.log("ALL CHECKS PASSED");

--- a/src/components/AudioControls/PlaybackProgressSlider.tsx
+++ b/src/components/AudioControls/PlaybackProgressSlider.tsx
@@ -9,6 +9,7 @@ interface PlaybackProgressSlider {
   setLoopRange: Dispatch<SetStateAction<[number, number]>>;
   setChordRepetitions: Dispatch<SetStateAction<number[]>>;
   scrollPositionsLength: number;
+  clearPausedStripScrollPosition?: () => void;
 }
 
 function PlaybackProgressSlider({
@@ -18,6 +19,7 @@ function PlaybackProgressSlider({
   setLoopRange,
   setChordRepetitions,
   scrollPositionsLength,
+  clearPausedStripScrollPosition,
 }: PlaybackProgressSlider) {
   const {
     currentChordIndex,
@@ -236,6 +238,7 @@ function PlaybackProgressSlider({
               setChordRepetitions(new Array(scrollPositionsLength).fill(0));
             }
 
+            clearPausedStripScrollPosition?.();
             setCurrentChordIndex(values[0]);
           }}
           renderTrack={({ props, children, disabled }) => (

--- a/src/components/Tab/Playback/PlaybackAudio/PlaybackAudioControls.tsx
+++ b/src/components/Tab/Playback/PlaybackAudio/PlaybackAudioControls.tsx
@@ -27,6 +27,7 @@ interface PlaybackAudioControls {
   setTabProgressValue: Dispatch<SetStateAction<number>>;
   setChordRepetitions: Dispatch<SetStateAction<number[]>>;
   scrollPositionsLength: number;
+  clearPausedStripScrollPosition?: () => void;
 }
 
 function PlaybackAudioControls({
@@ -37,6 +38,7 @@ function PlaybackAudioControls({
   setTabProgressValue,
   setChordRepetitions,
   scrollPositionsLength,
+  clearPausedStripScrollPosition,
 }: PlaybackAudioControls) {
   const {
     bpm,
@@ -265,6 +267,7 @@ function PlaybackAudioControls({
               setLoopRange={setLoopRange}
               setChordRepetitions={setChordRepetitions}
               scrollPositionsLength={scrollPositionsLength}
+              clearPausedStripScrollPosition={clearPausedStripScrollPosition}
             />
 
             <div className="baseFlex w-9 !justify-end self-start">
@@ -309,6 +312,7 @@ function PlaybackAudioControls({
             setLoopRange={setLoopRange}
             setChordRepetitions={setChordRepetitions}
             scrollPositionsLength={scrollPositionsLength}
+            clearPausedStripScrollPosition={clearPausedStripScrollPosition}
           />
 
           <div className="baseFlex w-full !justify-between">
@@ -382,6 +386,7 @@ function PlaybackAudioControls({
                   size={aboveLargeViewportWidth ? "default" : "sm"}
                   disabled={disablePlayButton}
                   onClick={handlePlayButtonClick}
+                  data-testid="playback-play-pause"
                   className="size-10 shrink-0 overflow-hidden rounded-full border-none bg-transparent p-0 text-foreground hover:bg-audio hover:text-audio-foreground disabled:border-none disabled:bg-transparent disabled:opacity-100"
                 >
                   <PlayButtonIcon

--- a/src/components/Tab/Playback/PlaybackModal.tsx
+++ b/src/components/Tab/Playback/PlaybackModal.tsx
@@ -101,6 +101,9 @@ function PlaybackModal() {
   // Per-chord repetition tracking for smooth infinite scroll without visual snapping
   // Each chord tracks how many times it has "looped" for positioning purposes
   const [chordRepetitions, setChordRepetitions] = useState<number[]>([]);
+  const [pausedStripScrollPx, setPausedStripScrollPx] = useState<number | null>(
+    null,
+  );
 
   // v avoids polluting the store with these extra semi-local values
   const [loopRange, setLoopRange] = useState<[number, number]>([
@@ -133,8 +136,15 @@ function PlaybackModal() {
   useEffect(() => {
     if (expandedTabData && expandedTabData.length > 0) {
       setChordRepetitions(new Array(expandedTabData.length).fill(0));
+      setPausedStripScrollPx(null);
     }
   }, [expandedTabData]);
+
+  useEffect(() => {
+    if (audioMetadata.playing) {
+      setPausedStripScrollPx(null);
+    }
+  }, [audioMetadata.playing]);
 
   // Compute chord layout data (positions, widths, durations) - memoized
   const chordLayoutData = useMemo<ChordLayoutData | null>(() => {
@@ -300,10 +310,17 @@ function PlaybackModal() {
     const { scrollPositions, totalWidth } = chordLayoutData;
     const chordCount = expandedTabData.length;
 
-    // Get current chord's scroll position using its repetition count
-    const currentScrollPosition =
+    const chordBoundaryScrollPosition =
       (scrollPositions[currentChordIndex] ?? 0) +
       (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
+
+    // While paused after WAAPI playback, preserve the exact animated strip position
+    // instead of snapping to chord boundaries. This avoids offscreen chords when
+    // pausing shortly after a loop while virtualization repetitions are catching up.
+    const currentScrollPosition =
+      !audioMetadata.playing && pausedStripScrollPx !== null
+        ? pausedStripScrollPx
+        : chordBoundaryScrollPosition;
 
     const halfViewport = visiblePlaybackContainerWidth / 2;
     const minVisiblePosition =
@@ -346,6 +363,8 @@ function PlaybackModal() {
     visiblePlaybackContainerWidth,
     currentChordIndex,
     chordRepetitions,
+    audioMetadata.playing,
+    pausedStripScrollPx,
   ]);
 
   // Primary chord virtualization effect - increments all chords except the last visible portion
@@ -434,6 +453,14 @@ function PlaybackModal() {
 
   const currentChordRepetition = chordRepetitions[currentChordIndex] ?? 0;
 
+  const handlePausedScrollPosition = useCallback((scrollPositionPx: number) => {
+    setPausedStripScrollPx(scrollPositionPx);
+  }, []);
+
+  const clearPausedStripScrollPosition = useCallback(() => {
+    setPausedStripScrollPx(null);
+  }, []);
+
   usePlaybackStripAnimation({
     stripRef: scrollStripRef,
     chordLayoutData,
@@ -442,6 +469,7 @@ function PlaybackModal() {
     audioContext,
     playbackStartedAtAudioTime,
     playing: audioMetadata.playing,
+    onPausedScrollPosition: handlePausedScrollPosition,
   });
 
   // Keep the inline transform at the current chord boundary.
@@ -456,9 +484,13 @@ function PlaybackModal() {
       return "translateX(0px)";
 
     const { scrollPositions, totalWidth } = chordLayoutData;
-    const position =
+    const chordBoundaryScrollPosition =
       (scrollPositions[currentChordIndex] ?? 0) +
       (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
+    const position =
+      !audioMetadata.playing && pausedStripScrollPx !== null
+        ? pausedStripScrollPx
+        : chordBoundaryScrollPosition;
 
     return `translateX(${position * -1}px)`;
   }, [
@@ -467,6 +499,8 @@ function PlaybackModal() {
     currentlyPlayingMetadata,
     currentChordIndex,
     chordRepetitions,
+    audioMetadata.playing,
+    pausedStripScrollPx,
   ]);
 
   const isChordHighlighted = useCallback(
@@ -616,6 +650,9 @@ function PlaybackModal() {
                     scrollPositionsLength={
                       chordLayoutData?.scrollPositions.length ?? 0
                     }
+                    clearPausedStripScrollPosition={
+                      clearPausedStripScrollPosition
+                    }
                   >
                     <div
                       ref={containerRef}
@@ -632,6 +669,7 @@ function PlaybackModal() {
                       {chordLayoutData && expandedTabData && (
                         <div
                           ref={scrollStripRef}
+                          data-testid="playback-scroll-strip"
                           style={{
                             width: `${chordLayoutData.totalWidth}px`,
                             transform: scrollContainerTransform,
@@ -668,6 +706,7 @@ function PlaybackModal() {
                               return (
                                 <div
                                   key={`${index}-${chordRepetitions[index] ?? 0}`}
+                                  data-testid="playback-chord"
                                   style={{
                                     position: "absolute",
                                     width: `${chordLayoutData.chordWidths[index] ?? 0}px`,
@@ -728,6 +767,7 @@ function PlaybackModal() {
                 scrollPositionsLength={
                   chordLayoutData?.scrollPositions.length ?? 0
                 }
+                clearPausedStripScrollPosition={clearPausedStripScrollPosition}
               />
 
               <PlaybackBottomMetadata

--- a/src/components/Tab/Playback/PlaybackModal.tsx
+++ b/src/components/Tab/Playback/PlaybackModal.tsx
@@ -104,6 +104,8 @@ function PlaybackModal() {
   const [pausedStripScrollPx, setPausedStripScrollPx] = useState<number | null>(
     null,
   );
+  const frozenStripScrollPxRef = useRef<number | null>(null);
+  const previousPlaybackContainerWidthRef = useRef(0);
 
   // v avoids polluting the store with these extra semi-local values
   const [loopRange, setLoopRange] = useState<[number, number]>([
@@ -143,8 +145,24 @@ function PlaybackModal() {
   useEffect(() => {
     if (audioMetadata.playing) {
       setPausedStripScrollPx(null);
+      frozenStripScrollPxRef.current = null;
     }
   }, [audioMetadata.playing]);
+
+  useEffect(() => {
+    if (
+      previousPlaybackContainerWidthRef.current !== 0 &&
+      previousPlaybackContainerWidthRef.current !==
+        visiblePlaybackContainerWidth &&
+      chordRepetitions.length > 0
+    ) {
+      setChordRepetitions(new Array(chordRepetitions.length).fill(0));
+      setPausedStripScrollPx(null);
+      frozenStripScrollPxRef.current = null;
+    }
+
+    previousPlaybackContainerWidthRef.current = visiblePlaybackContainerWidth;
+  }, [visiblePlaybackContainerWidth, chordRepetitions.length]);
 
   // Compute chord layout data (positions, widths, durations) - memoized
   const chordLayoutData = useMemo<ChordLayoutData | null>(() => {
@@ -317,16 +335,21 @@ function PlaybackModal() {
     // While paused after WAAPI playback, preserve the exact animated strip position
     // instead of snapping to chord boundaries. This avoids offscreen chords when
     // pausing shortly after a loop while virtualization repetitions are catching up.
+    const activePausedScrollPx =
+      pausedStripScrollPx ?? frozenStripScrollPxRef.current;
+
     const currentScrollPosition =
-      !audioMetadata.playing && pausedStripScrollPx !== null
-        ? pausedStripScrollPx
+      !audioMetadata.playing && activePausedScrollPx !== null
+        ? activePausedScrollPx
         : chordBoundaryScrollPosition;
 
-    const halfViewport = visiblePlaybackContainerWidth / 2;
     const minVisiblePosition =
-      currentScrollPosition - halfViewport - VIRTUALIZATION_BUFFER;
+      currentScrollPosition - initialPlaceholderWidth - VIRTUALIZATION_BUFFER;
     const maxVisiblePosition =
-      currentScrollPosition + halfViewport + VIRTUALIZATION_BUFFER;
+      currentScrollPosition -
+      initialPlaceholderWidth +
+      visiblePlaybackContainerWidth +
+      VIRTUALIZATION_BUFFER;
 
     // Find visible range - we need to check each chord's actual position with its repetition
     let startIndex = 0;
@@ -365,9 +388,10 @@ function PlaybackModal() {
     chordRepetitions,
     audioMetadata.playing,
     pausedStripScrollPx,
+    initialPlaceholderWidth,
   ]);
 
-  // Primary chord virtualization effect - increments all chords except the last visible portion
+  // Primary chord virtualization effect
   // Triggers when current chord index reaches the point where the last chord becomes visible
   useEffect(() => {
     if (
@@ -454,10 +478,12 @@ function PlaybackModal() {
   const currentChordRepetition = chordRepetitions[currentChordIndex] ?? 0;
 
   const handlePausedScrollPosition = useCallback((scrollPositionPx: number) => {
+    frozenStripScrollPxRef.current = scrollPositionPx;
     setPausedStripScrollPx(scrollPositionPx);
   }, []);
 
   const clearPausedStripScrollPosition = useCallback(() => {
+    frozenStripScrollPxRef.current = null;
     setPausedStripScrollPx(null);
   }, []);
 
@@ -487,9 +513,11 @@ function PlaybackModal() {
     const chordBoundaryScrollPosition =
       (scrollPositions[currentChordIndex] ?? 0) +
       (chordRepetitions[currentChordIndex] ?? 0) * totalWidth;
+    const activePausedScrollPx =
+      pausedStripScrollPx ?? frozenStripScrollPxRef.current;
     const position =
-      !audioMetadata.playing && pausedStripScrollPx !== null
-        ? pausedStripScrollPx
+      !audioMetadata.playing && activePausedScrollPx !== null
+        ? activePausedScrollPx
         : chordBoundaryScrollPosition;
 
     return `translateX(${position * -1}px)`;
@@ -673,9 +701,10 @@ function PlaybackModal() {
                           style={{
                             width: `${chordLayoutData.totalWidth}px`,
                             transform: scrollContainerTransform,
-                            transition: audioMetadata.playing
-                              ? "none"
-                              : "transform 0.2s linear",
+                            transition:
+                              audioMetadata.playing || pausedStripScrollPx !== null
+                                ? "none"
+                                : "transform 0.2s linear",
                           }}
                           className="relative flex items-center will-change-transform"
                         >
@@ -707,6 +736,7 @@ function PlaybackModal() {
                                 <div
                                   key={`${index}-${chordRepetitions[index] ?? 0}`}
                                   data-testid="playback-chord"
+                                  data-chord-index={index}
                                   style={{
                                     position: "absolute",
                                     width: `${chordLayoutData.chordWidths[index] ?? 0}px`,

--- a/src/components/Tab/Playback/PlaybackScrollingContainer.tsx
+++ b/src/components/Tab/Playback/PlaybackScrollingContainer.tsx
@@ -12,6 +12,7 @@ interface PlaybackScrollingContainerProps {
   loopCount: number;
   setChordRepetitions: Dispatch<SetStateAction<number[]>>;
   scrollPositionsLength: number;
+  clearPausedStripScrollPosition?: () => void;
 }
 
 // TODO: still want to avoid "translateX" reliance at all costs, but this approach is inherently
@@ -22,6 +23,7 @@ function PlaybackScrollingContainer({
   loopCount,
   setChordRepetitions,
   scrollPositionsLength,
+  clearPausedStripScrollPosition,
 }: PlaybackScrollingContainerProps) {
   const {
     playing,
@@ -47,6 +49,7 @@ function PlaybackScrollingContainer({
     if (expandedTabData === null) return;
 
     const newValue = currentChordIndex + 1;
+    clearPausedStripScrollPosition?.();
     setCurrentChordIndex(newValue > expandedTabData.length - 1 ? 0 : newValue);
   }
 
@@ -58,6 +61,7 @@ function PlaybackScrollingContainer({
 
     if (newValue < 0 && loopCount === 0) return;
 
+    clearPausedStripScrollPosition?.();
     setCurrentChordIndex(newValue < 0 ? expandedTabData.length - 1 : newValue);
   }
 
@@ -99,6 +103,7 @@ function PlaybackScrollingContainer({
   return (
     <div
       ref={containerRef}
+      data-testid="playback-scrolling-container"
       className="relative h-[230px] w-full cursor-grab touch-none overflow-hidden active:cursor-grabbing mobilePortrait:h-[255px]"
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}

--- a/src/hooks/usePlaybackStripAnimation.ts
+++ b/src/hooks/usePlaybackStripAnimation.ts
@@ -32,8 +32,13 @@ interface PlaybackStripAnimationData {
 const VELOCITY_EPSILON = 0.0001;
 
 function readStripScrollPosition(element: HTMLElement): number | null {
+  // Prefer computed style so an active WAAPI transform is captured even if React
+  // has already written a boundary transform to the inline style.
+  const computedTransform = getComputedStyle(element).transform;
   const transform =
-    element.style.transform || getComputedStyle(element).transform;
+    computedTransform && computedTransform !== "none"
+      ? computedTransform
+      : element.style.transform;
 
   if (!transform || transform === "none") return null;
 
@@ -150,9 +155,7 @@ function usePlaybackStripAnimation({
     [chordLayoutData],
   );
 
-  useEffect(() => {
-    playingRef.current = playing;
-  }, [playing]);
+  playingRef.current = playing;
 
   useLayoutEffect(() => {
     anchorChordIndexRef.current = currentChordIndex;
@@ -161,14 +164,6 @@ function usePlaybackStripAnimation({
 
   useLayoutEffect(() => {
     const currentAnimation = animationRef.current;
-    const animatedElement = stripRef.current;
-
-    if (!playing && currentAnimation && animatedElement) {
-      const scrollPosition = readStripScrollPosition(animatedElement);
-      if (scrollPosition !== null) {
-        onPausedScrollPosition?.(scrollPosition);
-      }
-    }
 
     if (currentAnimation) {
       currentAnimation.onfinish = null;
@@ -254,6 +249,15 @@ function usePlaybackStripAnimation({
 
     return () => {
       const activeAnimation = animationRef.current;
+      const animatedElement = stripRef.current;
+
+      if (activeAnimation && animatedElement && !playingRef.current) {
+        const scrollPosition = readStripScrollPosition(animatedElement);
+        if (scrollPosition !== null) {
+          onPausedScrollPosition?.(scrollPosition);
+        }
+      }
+
       if (activeAnimation) {
         activeAnimation.onfinish = null;
         activeAnimation.cancel();

--- a/src/hooks/usePlaybackStripAnimation.ts
+++ b/src/hooks/usePlaybackStripAnimation.ts
@@ -20,6 +20,7 @@ interface UsePlaybackStripAnimationArgs {
   audioContext: AudioContext | null;
   playbackStartedAtAudioTime: number | null;
   playing: boolean;
+  onPausedScrollPosition?: (scrollPositionPx: number) => void;
 }
 
 interface PlaybackStripAnimationData {
@@ -29,6 +30,21 @@ interface PlaybackStripAnimationData {
 }
 
 const VELOCITY_EPSILON = 0.0001;
+
+function readStripScrollPosition(element: HTMLElement): number | null {
+  const transform =
+    element.style.transform || getComputedStyle(element).transform;
+
+  if (!transform || transform === "none") return null;
+
+  if (transform.startsWith("matrix")) {
+    const matrix = new DOMMatrix(transform);
+    return Math.abs(matrix.m41);
+  }
+
+  const match = transform.match(/translateX\((-?\d+(?:\.\d+)?)px\)/);
+  return match ? Math.abs(Number(match[1])) : null;
+}
 
 function getPlaybackStripAnimationData(
   chordLayoutData: PlaybackStripLayoutData | null,
@@ -120,6 +136,7 @@ function usePlaybackStripAnimation({
   audioContext,
   playbackStartedAtAudioTime,
   playing,
+  onPausedScrollPosition,
 }: UsePlaybackStripAnimationArgs) {
   const animationRef = useRef<Animation | null>(null);
   const animationGenerationRef = useRef(0);
@@ -144,6 +161,15 @@ function usePlaybackStripAnimation({
 
   useLayoutEffect(() => {
     const currentAnimation = animationRef.current;
+    const animatedElement = stripRef.current;
+
+    if (!playing && currentAnimation && animatedElement) {
+      const scrollPosition = readStripScrollPosition(animatedElement);
+      if (scrollPosition !== null) {
+        onPausedScrollPosition?.(scrollPosition);
+      }
+    }
+
     if (currentAnimation) {
       currentAnimation.onfinish = null;
       currentAnimation.cancel();
@@ -243,6 +269,7 @@ function usePlaybackStripAnimation({
     playbackStartedAtAudioTime,
     playing,
     stripRef,
+    onPausedScrollPosition,
   ]);
 }
 

--- a/src/pages/dev-playback-harness.tsx
+++ b/src/pages/dev-playback-harness.tsx
@@ -93,7 +93,6 @@ export default function DevPlaybackHarness() {
     setPlaybackSpeed,
     setCountInTimerEnabled,
     setShowPlaybackModal,
-    setVisiblePlaybackContainerWidth,
     setAudioMetadata,
     setCurrentChordIndex,
     storeTabData,
@@ -110,7 +109,6 @@ export default function DevPlaybackHarness() {
     setPlaybackSpeed: state.setPlaybackSpeed,
     setCountInTimerEnabled: state.setCountInTimerEnabled,
     setShowPlaybackModal: state.setShowPlaybackModal,
-    setVisiblePlaybackContainerWidth: state.setVisiblePlaybackContainerWidth,
     setAudioMetadata: state.setAudioMetadata,
     setCurrentChordIndex: state.setCurrentChordIndex,
     storeTabData: state.tabData,
@@ -146,7 +144,6 @@ export default function DevPlaybackHarness() {
     setPlaybackSpeed(1.5);
     setCountInTimerEnabled(false);
     setCurrentChordIndex(0);
-    setVisiblePlaybackContainerWidth(1280);
     setAudioMetadata({
       playing: false,
       location: null,
@@ -169,7 +166,6 @@ export default function DevPlaybackHarness() {
     setPlaybackSpeed,
     setCountInTimerEnabled,
     setShowPlaybackModal,
-    setVisiblePlaybackContainerWidth,
     setAudioMetadata,
     setCurrentChordIndex,
   ]);

--- a/src/pages/dev-playback-harness.tsx
+++ b/src/pages/dev-playback-harness.tsx
@@ -1,0 +1,245 @@
+// Dev-only harness for verifying playback modal loop/pause behavior.
+// Exercised by scripts/verifyPlaybackPauseAfterLoop.mjs; returns 404 in production.
+//
+// Query params:
+// - chords=60 (default) number of tab note columns in one subsection
+import ErrorPage from "next/error";
+import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence } from "framer-motion";
+import useAutoCompileChords from "~/hooks/useAutoCompileChords";
+import {
+  useTabStore,
+  type Section,
+  type TabNote,
+  type TabMeasureLine,
+} from "~/stores/TabStore";
+
+const PlaybackModal = dynamic(
+  () => import("~/components/Tab/Playback/PlaybackModal"),
+  { ssr: false },
+);
+
+function note(id: string): TabNote {
+  return {
+    type: "note",
+    palmMute: "",
+    firstString: "",
+    secondString: "3",
+    thirdString: "2",
+    fourthString: "0",
+    fifthString: "",
+    sixthString: "",
+    chordEffects: "",
+    noteLength: "quarter",
+    id,
+  };
+}
+
+function measureLine(id: string): TabMeasureLine {
+  return {
+    type: "measureLine",
+    isInPalmMuteSection: false,
+    bpmAfterLine: null,
+    id,
+  };
+}
+
+function makeColumns(chordCount: number) {
+  const columns: (TabNote | TabMeasureLine)[] = [];
+  const measures = Math.ceil(chordCount / 8);
+
+  for (let m = 0; m < measures; m++) {
+    for (let n = 0; n < 8; n++) {
+      if (columns.length >= chordCount) break;
+      columns.push(note(`n-${m}-${n}`));
+    }
+    if (m < measures - 1 && columns.length < chordCount) {
+      columns.push(measureLine(`ml-${m}`));
+    }
+  }
+
+  return columns;
+}
+
+function buildTabData(chordCount: number): Section[] {
+  return [
+    {
+      id: "playback-harness-section",
+      title: "Playback harness",
+      data: [
+        {
+          id: "playback-harness-sub",
+          type: "tab" as const,
+          bpm: 480,
+          baseNoteLength: "quarter" as const,
+          repetitions: 1,
+          data: makeColumns(chordCount),
+        },
+      ],
+    },
+  ];
+}
+
+export default function DevPlaybackHarness() {
+  const { query, isReady } = useRouter();
+
+  const {
+    setId,
+    setTabData,
+    setEditing,
+    setBpm,
+    setPlaybackSpeed,
+    setCountInTimerEnabled,
+    setShowPlaybackModal,
+    setVisiblePlaybackContainerWidth,
+    setAudioMetadata,
+    setCurrentChordIndex,
+    storeTabData,
+    showPlaybackModal,
+    expandedTabData,
+    audioMetadata,
+    currentChordIndex,
+    pauseAudio,
+  } = useTabStore((state) => ({
+    setId: state.setId,
+    setTabData: state.setTabData,
+    setEditing: state.setEditing,
+    setBpm: state.setBpm,
+    setPlaybackSpeed: state.setPlaybackSpeed,
+    setCountInTimerEnabled: state.setCountInTimerEnabled,
+    setShowPlaybackModal: state.setShowPlaybackModal,
+    setVisiblePlaybackContainerWidth: state.setVisiblePlaybackContainerWidth,
+    setAudioMetadata: state.setAudioMetadata,
+    setCurrentChordIndex: state.setCurrentChordIndex,
+    storeTabData: state.tabData,
+    showPlaybackModal: state.showPlaybackModal,
+    expandedTabData: state.expandedTabData,
+    audioMetadata: state.audioMetadata,
+    currentChordIndex: state.currentChordIndex,
+    pauseAudio: state.pauseAudio,
+  }));
+
+  const previousChordIndexRef = useRef(0);
+  const [hasCompletedLoop, setHasCompletedLoop] = useState(false);
+
+  const chordCount = Math.max(
+    20,
+    Number(typeof query.chords === "string" ? query.chords : "60") || 60,
+  );
+  const tabData = useMemo(() => buildTabData(chordCount), [chordCount]);
+
+  const ready =
+    storeTabData[0]?.id === tabData[0]?.id &&
+    expandedTabData !== null &&
+    expandedTabData.length > 0;
+
+  useAutoCompileChords();
+
+  useEffect(() => {
+    if (!isReady) return;
+
+    setId(1);
+    setEditing(false);
+    setBpm(480);
+    setPlaybackSpeed(1.5);
+    setCountInTimerEnabled(false);
+    setCurrentChordIndex(0);
+    setVisiblePlaybackContainerWidth(1280);
+    setAudioMetadata({
+      playing: false,
+      location: null,
+      startLoopIndex: 0,
+      endLoopIndex: -1,
+      editingLoopRange: false,
+      fullCurrentlyPlayingMetadataLength: -1,
+    });
+    setTabData((draft) => {
+      draft.splice(0, draft.length, ...tabData);
+    });
+    setShowPlaybackModal(true);
+  }, [
+    isReady,
+    tabData,
+    setId,
+    setTabData,
+    setEditing,
+    setBpm,
+    setPlaybackSpeed,
+    setCountInTimerEnabled,
+    setShowPlaybackModal,
+    setVisiblePlaybackContainerWidth,
+    setAudioMetadata,
+    setCurrentChordIndex,
+  ]);
+
+  useEffect(() => {
+    const chordTotal = expandedTabData?.length ?? 0;
+
+    if (
+      chordTotal > 0 &&
+      previousChordIndexRef.current > chordTotal * 0.4 &&
+      currentChordIndex < chordTotal * 0.15
+    ) {
+      setHasCompletedLoop(true);
+    }
+
+    previousChordIndexRef.current = currentChordIndex;
+  }, [currentChordIndex, expandedTabData]);
+
+  useEffect(() => {
+    if (audioMetadata.playing) {
+      setHasCompletedLoop(false);
+    }
+  }, [audioMetadata.playing]);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      (
+        window as Window & {
+          __playbackHarness?: {
+            ready: boolean;
+            chordCount: number;
+            currentChordIndex: number;
+            playing: boolean;
+            hasCompletedLoop: boolean;
+            pause: () => void;
+          };
+        }
+      ).__playbackHarness = {
+        ready,
+        chordCount: expandedTabData?.length ?? 0,
+        currentChordIndex,
+        playing: audioMetadata.playing,
+        hasCompletedLoop,
+        pause: () => pauseAudio(),
+      };
+    }
+  }, [
+    ready,
+    expandedTabData,
+    currentChordIndex,
+    audioMetadata.playing,
+    hasCompletedLoop,
+    pauseAudio,
+  ]);
+
+  if (process.env.NODE_ENV === "production") {
+    return <ErrorPage statusCode={404} />;
+  }
+
+  return (
+    <div
+      id="devPlaybackHarness"
+      data-ready={ready}
+      data-playing={audioMetadata.playing}
+      data-chord-count={expandedTabData?.length ?? 0}
+      className="fixed inset-0 z-[60]"
+    >
+      <AnimatePresence mode="wait">
+        {showPlaybackModal && <PlaybackModal />}
+      </AnimatePresence>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Pausing playback shortly after a full loop could leave part or all chords invisible/offscreen. Manual scrolling still worked because advancing `currentChordIndex` recomputed the strip position from chord boundaries.

## Root cause

During playback, WAAPI owns the strip transform while chord virtualization tracks per-chord loop repetitions. On pause, the animation was cancelled without preserving its current transform, and the UI snapped to a chord-boundary position derived from `currentChordIndex` + `chordRepetitions[index]`.

Right after a loop, those values can lag the true animated position (especially while repetition catch-up is in progress), so the strip jumped and `visibleRange` culled the wrong chords.

## Fix

- Capture the strip's animated scroll offset from computed style **before** cancelling WAAPI on pause
- Use that preserved offset for both `scrollContainerTransform` and `visibleRange` while paused
- Clear the preserved offset when resuming playback, scrubbing, or manually scrolling

## Verification

Added a dev harness (`/dev-playback-harness`) and Playwright script:

```bash
npm run dev
node scripts/verifyPlaybackPauseAfterLoop.mjs
```

The script checks chord visibility and strip-position stability across desktop/mobile viewports when pausing after loop completion. Ran successfully 3 consecutive times locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5a51a50-757e-4ce9-802b-23c85d5ff8c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5a51a50-757e-4ce9-802b-23c85d5ff8c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

