### PR TITLE
Add chord lookahead scheduler for tab playback

### DIFF
--- a/src/stores/TabStore.ts
+++ b/src/stores/TabStore.ts
@@ -964,6 +964,7 @@ const useTabStoreBase = create<TabState>()(
               looping: state.looping,
               showPlaybackModal: state.showPlaybackModal,
               audioMetadata: state.audioMetadata,
+              currentChordIndex: state.currentChordIndex,
             };
           },
           setState: (partial) => set(partial),

--- a/src/stores/TabStore.ts
+++ b/src/stores/TabStore.ts
@@ -13,6 +13,10 @@ import {
 import { resetProgressTabSliderPosition } from "~/utils/tabSliderHelpers";
 import { DEFAULT_TUNING, normalizeTuningValue, parse } from "~/utils/tunings";
 import { expandFullTab } from "~/utils/playbackChordCompilationHelpers";
+import {
+  PLAYBACK_START_EPSILON_SECONDS,
+  runPlaybackScheduler,
+} from "~/utils/playbackScheduler";
 import { useShallow } from "zustand/shallow";
 
 export interface SectionProgression {
@@ -581,6 +585,8 @@ interface TabState {
   currentChordIndex: number;
   setCurrentChordIndex: (currentChordIndex: number) => void;
   playbackStartedAtAudioTime: number | null;
+  playbackSessionId: number;
+  scheduledPlaybackNodes: { stop(when?: number): void }[];
   audioMetadata: AudioMetadata;
   setAudioMetadata: (audioMetadata: AudioMetadata) => void;
   instruments: Record<InstrumentNames, Soundfont.Player>;
@@ -771,6 +777,8 @@ const useTabStoreBase = create<TabState>()(
       currentChordIndex: 0,
       setCurrentChordIndex: (currentChordIndex) => set({ currentChordIndex }),
       playbackStartedAtAudioTime: null,
+      playbackSessionId: 0,
+      scheduledPlaybackNodes: [],
       audioMetadata: {
         playing: false,
         location: null,
@@ -913,10 +921,11 @@ const useTabStoreBase = create<TabState>()(
             : expandedTabData.artificialLoopsNecessary);
 
         // Web Audio is most reliable when you schedule sounds slightly ahead of audioContext.currentTime
-        const playbackStartEpsilonSeconds = 0.03;
+        const nextPlaybackSessionId = get().playbackSessionId + 1;
+        const scheduledPlaybackNodes: { stop(when?: number): void }[] = [];
 
         let nextChordStartTime =
-          audioContext.currentTime + playbackStartEpsilonSeconds;
+          audioContext.currentTime + PLAYBACK_START_EPSILON_SECONDS;
 
         set({
           audioMetadata: {
@@ -925,111 +934,42 @@ const useTabStoreBase = create<TabState>()(
             playing: true,
           },
           playbackStartedAtAudioTime: nextChordStartTime,
+          playbackSessionId: nextPlaybackSessionId,
+          scheduledPlaybackNodes,
+          breakOnNextChord: false,
         });
 
-        for (
-          let chordIndex = currentChordIndex;
-          chordIndex < adjChordCount;
-          chordIndex++
-        ) {
-          const adjChordIndex = chordIndex % compiledChords.length;
-          const currColumn = compiledChords[adjChordIndex];
+        const activeSessionId = nextPlaybackSessionId;
 
-          // Proceed only if the current column is defined and not ornamental (has length > 0)
-          if (currColumn && currColumn.length > 0) {
-            set({
-              currentChordIndex: chordIndex,
-            });
-
-            const thirdPrevColumn = compiledChords[adjChordIndex - 3];
-            const secondPrevColumn = compiledChords[adjChordIndex - 2];
-            const prevColumn = compiledChords[adjChordIndex - 1];
-            const nextColumn = compiledChords[adjChordIndex + 1];
-
-            // Calculate the altered BPM
-            const noteLengthMultiplier =
-              noteLengthMultipliers[currColumn[8] as FullNoteLengths];
-
-            const baseBpm = Number(currColumn[9]);
-
-            const effectiveBpm =
-              baseBpm * (1 / noteLengthMultiplier) * playbackSpeed;
-
-            const chordDuration = 60 / effectiveBpm;
-
-            // Play the current chord
-            await playNoteColumn({
-              tuning,
-              capo: capo ?? 0,
-              bpm: effectiveBpm,
-              targetStartTime: nextChordStartTime,
-              thirdPrevColumn,
-              secondPrevColumn,
-              prevColumn,
-              currColumn,
-              nextColumn,
-              audioContext,
-              masterVolumeGainNode,
-              currentInstrument,
-              currentlyPlayingStrings,
-            });
-
-            nextChordStartTime += chordDuration;
-          }
-
-          // If the current chord is the last in the compiledChords sequence
-          if (
-            // TODO: probably want to have reset of slider to beginning at the very first
-            // loop delay spacer chord (if there is one).
-            adjChordIndex ===
-            compiledChords.length - 1
-          ) {
-            resetProgressTabSliderPosition(editing ? "editing" : "playback");
-          }
-
-          // Since we are in a loop, we need to get up-to-date state values
-          const {
-            audioMetadata,
-            breakOnNextChord,
-            looping,
-            showPlaybackModal,
-          } = get();
-
-          // Tab has been paused, so we should stop the playback loop
-          if (breakOnNextChord) {
-            set({
-              breakOnNextChord: false,
-            });
-            return;
-          }
-
-          // Handle the end of the entire repeat sequence
-          if (
-            chordIndex === adjChordCount - 1 &&
-            (looping || showPlaybackModal) &&
-            audioMetadata.playing
-          ) {
-            // Reset the current chord index to 0 to start over.
-            // WAAPI onfinish owns visual loop chaining; keep the original audio
-            // anchor so the strip animation is not torn down and recreated.
-            set({
-              currentChordIndex: 0,
-            });
-
-            // Reset chordIndex to -1 so that after the loop's increment, it becomes 0
-            chordIndex = -1;
-          } else if (!looping && chordIndex === adjChordCount - 1) {
-            // If not looping, stop the playback and set currentChordIndex to 0
-            set({
-              currentChordIndex: 0,
-              playbackStartedAtAudioTime: null,
-              audioMetadata: {
-                ...audioMetadata,
-                playing: false,
-              },
-            });
-          }
-        }
+        await runPlaybackScheduler({
+          compiledChords,
+          adjChordCount,
+          startChordIndex: currentChordIndex,
+          playbackStartTime: nextChordStartTime,
+          playbackSpeed,
+          tuning,
+          capo: capo ?? 0,
+          audioContext,
+          masterVolumeGainNode,
+          currentInstrument,
+          currentlyPlayingStrings,
+          scheduledNodes: scheduledPlaybackNodes,
+          playbackSessionId: activeSessionId,
+          editing,
+          isSessionValid: () => get().playbackSessionId === activeSessionId,
+          getState: () => {
+            const state = get();
+            return {
+              breakOnNextChord: state.breakOnNextChord,
+              looping: state.looping,
+              showPlaybackModal: state.showPlaybackModal,
+              audioMetadata: state.audioMetadata,
+            };
+          },
+          setState: (partial) => set(partial),
+          resetProgressTabSliderPosition,
+          clearBreakOnNextChord: () => set({ breakOnNextChord: false }),
+        });
       },
 
       playPreview: async ({
@@ -1146,7 +1086,22 @@ const useTabStoreBase = create<TabState>()(
       },
 
       pauseAudio: (resetToStart, resetCurrentlyPlayingMetadata) => {
-        const { audioMetadata, previewMetadata, currentInstrument } = get();
+        const {
+          audioMetadata,
+          previewMetadata,
+          currentInstrument,
+          scheduledPlaybackNodes,
+        } = get();
+
+        for (const scheduledNode of scheduledPlaybackNodes) {
+          try {
+            scheduledNode.stop();
+          } catch {
+            // Node may already have stopped.
+          }
+        }
+
+        const nextPlaybackSessionId = get().playbackSessionId + 1;
 
         if (
           !audioMetadata.playing &&
@@ -1163,6 +1118,8 @@ const useTabStoreBase = create<TabState>()(
           set({
             currentChordIndex: 0,
             playbackStartedAtAudioTime: null,
+            playbackSessionId: nextPlaybackSessionId,
+            scheduledPlaybackNodes: [],
           });
           return;
         }
@@ -1181,6 +1138,8 @@ const useTabStoreBase = create<TabState>()(
             },
             playbackStartedAtAudioTime: null,
             breakOnNextChord: true,
+            playbackSessionId: nextPlaybackSessionId,
+            scheduledPlaybackNodes: [],
           });
 
           if (resetToStart) {
@@ -1197,6 +1156,8 @@ const useTabStoreBase = create<TabState>()(
               playing: false,
             },
             breakOnNextPreviewChord: true,
+            playbackSessionId: nextPlaybackSessionId,
+            scheduledPlaybackNodes: [],
           });
 
           if (resetToStart) {
@@ -1205,6 +1166,11 @@ const useTabStoreBase = create<TabState>()(
               currentChordIndex: 0,
             });
           }
+        } else {
+          set({
+            playbackSessionId: nextPlaybackSessionId,
+            scheduledPlaybackNodes: [],
+          });
         }
 
         currentInstrument?.stop();

--- a/src/stores/TabStore.ts
+++ b/src/stores/TabStore.ts
@@ -3,7 +3,11 @@ import type Soundfont from "soundfont-player";
 import { devtools } from "zustand/middleware";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
-import { playNoteColumn } from "~/utils/playGeneratedAudioHelpers";
+import {
+  playNoteColumn,
+  stopActivePlaybackStrings,
+  stopAllScheduledPlaybackNodes,
+} from "~/utils/playGeneratedAudioHelpers";
 import {
   compileFullTab,
   compileSpecificChordGrouping,
@@ -587,6 +591,11 @@ interface TabState {
   playbackStartedAtAudioTime: number | null;
   playbackSessionId: number;
   scheduledPlaybackNodes: { stop(when?: number): void }[];
+  activePlaybackStrings: (
+    | Soundfont.Player
+    | AudioBufferSourceNode
+    | undefined
+  )[] | null;
   audioMetadata: AudioMetadata;
   setAudioMetadata: (audioMetadata: AudioMetadata) => void;
   instruments: Record<InstrumentNames, Soundfont.Player>;
@@ -779,6 +788,7 @@ const useTabStoreBase = create<TabState>()(
       playbackStartedAtAudioTime: null,
       playbackSessionId: 0,
       scheduledPlaybackNodes: [],
+      activePlaybackStrings: null,
       audioMetadata: {
         playing: false,
         location: null,
@@ -936,6 +946,7 @@ const useTabStoreBase = create<TabState>()(
           playbackStartedAtAudioTime: nextChordStartTime,
           playbackSessionId: nextPlaybackSessionId,
           scheduledPlaybackNodes,
+          activePlaybackStrings: currentlyPlayingStrings,
           breakOnNextChord: false,
         });
 
@@ -1092,15 +1103,15 @@ const useTabStoreBase = create<TabState>()(
           previewMetadata,
           currentInstrument,
           scheduledPlaybackNodes,
+          activePlaybackStrings,
+          audioContext,
         } = get();
 
-        for (const scheduledNode of scheduledPlaybackNodes) {
-          try {
-            scheduledNode.stop();
-          } catch {
-            // Node may already have stopped.
-          }
-        }
+        const stopTime = audioContext?.currentTime ?? 0;
+
+        stopAllScheduledPlaybackNodes(scheduledPlaybackNodes, stopTime);
+        stopActivePlaybackStrings(activePlaybackStrings, stopTime);
+        currentInstrument?.stop(stopTime);
 
         const nextPlaybackSessionId = get().playbackSessionId + 1;
 
@@ -1121,6 +1132,7 @@ const useTabStoreBase = create<TabState>()(
             playbackStartedAtAudioTime: null,
             playbackSessionId: nextPlaybackSessionId,
             scheduledPlaybackNodes: [],
+            activePlaybackStrings: null,
           });
           return;
         }
@@ -1141,6 +1153,7 @@ const useTabStoreBase = create<TabState>()(
             breakOnNextChord: true,
             playbackSessionId: nextPlaybackSessionId,
             scheduledPlaybackNodes: [],
+            activePlaybackStrings: null,
           });
 
           if (resetToStart) {
@@ -1159,6 +1172,7 @@ const useTabStoreBase = create<TabState>()(
             breakOnNextPreviewChord: true,
             playbackSessionId: nextPlaybackSessionId,
             scheduledPlaybackNodes: [],
+            activePlaybackStrings: null,
           });
 
           if (resetToStart) {
@@ -1171,10 +1185,9 @@ const useTabStoreBase = create<TabState>()(
           set({
             playbackSessionId: nextPlaybackSessionId,
             scheduledPlaybackNodes: [],
+            activePlaybackStrings: null,
           });
         }
-
-        currentInstrument?.stop();
       },
 
       expandedTabData: null,

--- a/src/utils/playGeneratedAudioHelpers.ts
+++ b/src/utils/playGeneratedAudioHelpers.ts
@@ -148,7 +148,7 @@ function applyBendOrReleaseEffect({
 
   if (!pluckBaseNote && note) {
     // @ts-expect-error TODO: fix type
-    note.source.stop(0);
+    note.source.stop(audioContext.currentTime + when);
 
     source = audioContext.createBufferSource();
     sourceGain = audioContext.createGain();
@@ -160,7 +160,11 @@ function applyBendOrReleaseEffect({
 
     // @ts-expect-error TODO: fix type
     source.buffer = note.source.buffer as AudioBuffer;
-    source.start(0, 0.5, isPalmMuted ? 0.45 : undefined);
+    source.start(
+      audioContext.currentTime + when,
+      0.5,
+      isPalmMuted ? 0.45 : undefined,
+    );
 
     sourceGain.gain.setValueAtTime(0.01, audioContext.currentTime + when);
     sourceGain.gain.linearRampToValueAtTime(
@@ -236,6 +240,7 @@ interface PlayDeadNote {
   fret: number;
   accented: boolean;
   palmMuted: boolean;
+  when: number;
   audioContext: AudioContext;
   masterVolumeGainNode: GainNode;
   currentlyPlayingStrings: (
@@ -243,6 +248,7 @@ interface PlayDeadNote {
     | AudioBufferSourceNode
     | undefined
   )[];
+  scheduledNodes?: { stop(when?: number): void }[];
 }
 
 function playDeadNote({
@@ -250,12 +256,15 @@ function playDeadNote({
   fret,
   accented,
   palmMuted,
+  when,
   audioContext,
   masterVolumeGainNode,
   currentlyPlayingStrings,
+  scheduledNodes,
 }: PlayDeadNote) {
-  // stopping any note on string that is currently playing
-  currentlyPlayingStrings[stringIdx]?.stop();
+  setTimeout(() => {
+    currentlyPlayingStrings[stringIdx]?.stop();
+  }, when * 1000);
 
   const frequency = mapStringAndFretToOscillatorFrequency(
     stringIdx,
@@ -300,11 +309,11 @@ function playDeadNote({
       break;
   }
 
-  gainNode.gain.setValueAtTime(gainTarget, audioContext.currentTime);
-  gainNode.gain.exponentialRampToValueAtTime(
-    0.0001,
-    audioContext.currentTime + 0.1,
-  );
+  const startTime = audioContext.currentTime + when;
+  const endTime = startTime + 0.1;
+
+  gainNode.gain.setValueAtTime(gainTarget, startTime);
+  gainNode.gain.exponentialRampToValueAtTime(0.0001, endTime);
 
   // Create a BiquadFilterNode for a low-pass filter
   const highpassFilter = audioContext.createBiquadFilter();
@@ -327,17 +336,17 @@ function playDeadNote({
   gainNode.connect(masterVolumeGainNode);
   masterVolumeGainNode.connect(audioContext.destination);
 
-  // Start the oscillator and noise now
-  oscillator.start(audioContext.currentTime);
+  oscillator.start(startTime);
+  oscillator.stop(endTime);
 
-  // Stop the oscillator and noise shortly afterward to simulate a short, percussive sound
-  oscillator.stop(audioContext.currentTime + 0.1);
+  scheduledNodes?.push(oscillator);
 }
 
 interface PlaySlapSound {
   accented: boolean;
   stacatto?: boolean;
   palmMuted: boolean;
+  when: number;
   audioContext: AudioContext;
   masterVolumeGainNode: GainNode;
   currentlyPlayingStrings: (
@@ -345,20 +354,24 @@ interface PlaySlapSound {
     | AudioBufferSourceNode
     | undefined
   )[];
+  scheduledNodes?: { stop(when?: number): void }[];
 }
 
 function playSlapSound({
   accented,
   stacatto,
   palmMuted,
+  when,
   audioContext,
   masterVolumeGainNode,
   currentlyPlayingStrings,
+  scheduledNodes,
 }: PlaySlapSound) {
-  // stopping all notes currently playing
-  for (const currentlyPlayingString of currentlyPlayingStrings) {
-    currentlyPlayingString?.stop();
-  }
+  setTimeout(() => {
+    for (const currentlyPlayingString of currentlyPlayingStrings) {
+      currentlyPlayingString?.stop();
+    }
+  }, when * 1000);
 
   // Create an OscillatorNode to simulate the slap sound
   const oscillator = audioContext.createOscillator();
@@ -397,11 +410,11 @@ function playSlapSound({
     gainTarget *= 1.25;
   }
 
-  gainNode.gain.setValueAtTime(gainTarget, audioContext.currentTime);
-  gainNode.gain.exponentialRampToValueAtTime(
-    0.01,
-    audioContext.currentTime + duration,
-  );
+  const startTime = audioContext.currentTime + when;
+  const endTime = startTime + duration;
+
+  gainNode.gain.setValueAtTime(gainTarget, startTime);
+  gainNode.gain.exponentialRampToValueAtTime(0.01, endTime);
 
   // Create a BiquadFilterNode for a low-pass filter
   const lowPassFilter = audioContext.createBiquadFilter();
@@ -417,11 +430,8 @@ function playSlapSound({
 
   // Create a GainNode for the noise volume
   const noiseGain = audioContext.createGain();
-  noiseGain.gain.setValueAtTime(0.2, audioContext.currentTime);
-  noiseGain.gain.exponentialRampToValueAtTime(
-    0.01,
-    audioContext.currentTime + duration,
-  );
+  noiseGain.gain.setValueAtTime(0.2, startTime);
+  noiseGain.gain.exponentialRampToValueAtTime(0.01, endTime);
 
   // Connect the oscillator and noise to the gainNode
   oscillator.connect(lowPassFilter);
@@ -434,13 +444,12 @@ function playSlapSound({
   gainNode.connect(masterVolumeGainNode);
   masterVolumeGainNode.connect(audioContext.destination);
 
-  // Start the oscillator and noise now
-  oscillator.start(audioContext.currentTime);
-  noise.start(audioContext.currentTime);
+  oscillator.start(startTime);
+  noise.start(startTime);
+  oscillator.stop(endTime);
+  noise.stop(endTime);
 
-  // Stop the oscillator and noise shortly afterward to simulate a short, percussive sound
-  oscillator.stop(audioContext.currentTime + duration);
-  noise.stop(audioContext.currentTime + duration);
+  scheduledNodes?.push(oscillator, noise);
 }
 
 interface ApplyPalmMute {
@@ -532,7 +541,7 @@ function applyTetheredEffect({
   // immediately stop current note because we don't ever want to hear the pluck on
   // a tethered note
   // @ts-expect-error TODO: fix type
-  note.source.stop(0);
+  note.source.stop(audioContext.currentTime + when);
 
   const source = audioContext.createBufferSource();
   const sourceGain = audioContext.createGain();
@@ -634,7 +643,7 @@ function applyVibratoEffect({
 
   if (!pluckBaseNote && note) {
     // @ts-expect-error TODO: fix type
-    note.source.stop(0);
+    note.source.stop(audioContext.currentTime + when);
     source = audioContext.createBufferSource();
     sourceGain = audioContext.createGain();
 
@@ -645,7 +654,7 @@ function applyVibratoEffect({
 
     // @ts-expect-error TODO: fix type
     source.buffer = note.source.buffer as AudioBuffer;
-    source.start(0, 0.5);
+    source.start(audioContext.currentTime + when, 0.5);
 
     sourceGain.gain.setValueAtTime(0.01, audioContext.currentTime + when);
     sourceGain.gain.exponentialRampToValueAtTime(
@@ -858,6 +867,7 @@ interface PlayNoteColumn {
   strumDelayMultiplierScale?: number;
   acousticSteelOverrideForPreview?: Soundfont.Player;
   forTuningPreview?: boolean;
+  scheduledNodes?: { stop(when?: number): void }[];
 }
 
 function playNoteColumn({
@@ -877,6 +887,7 @@ function playNoteColumn({
   strumDelayMultiplierScale,
   acousticSteelOverrideForPreview,
   forTuningPreview,
+  scheduledNodes,
 }: PlayNoteColumn) {
   return new Promise<void>((resolve) => {
     const chordDuration = 60 / bpm;
@@ -884,6 +895,7 @@ function playNoteColumn({
     const scheduledEndTime = scheduledStartTime + chordDuration;
     const secondsUntilScheduledEnd =
       scheduledEndTime - audioContext.currentTime;
+    const baseWhen = Math.max(0, scheduledStartTime - audioContext.currentTime);
 
     const resolveDelayMs = Math.max(0, secondsUntilScheduledEnd * 1000);
 
@@ -905,15 +917,18 @@ function playNoteColumn({
           accented: currColumn[7].includes(">"),
           stacatto: currColumn[7].includes("."),
           palmMuted: currColumn[0] !== "",
+          when: baseWhen,
           audioContext,
           masterVolumeGainNode,
           currentlyPlayingStrings,
+          scheduledNodes,
         });
       } else if (currColumn[7] === "r") {
-        // stopping all notes currently playing
-        for (const currentlyPlayingString of currentlyPlayingStrings) {
-          currentlyPlayingString?.stop();
-        }
+        setTimeout(() => {
+          for (const currentlyPlayingString of currentlyPlayingStrings) {
+            currentlyPlayingString?.stop();
+          }
+        }, baseWhen * 1000);
       }
       return;
     }
@@ -953,9 +968,11 @@ function playNoteColumn({
           fret: capo === 0 ? 1 : capo,
           accented: currColumn[7]?.includes(">") || false,
           palmMuted: currColumn[0] !== "",
+          when: baseWhen + chordDelayMultiplier * notesPlayedSoFar,
           audioContext,
           masterVolumeGainNode,
           currentlyPlayingStrings,
+          scheduledNodes,
         });
 
         continue;
@@ -1223,9 +1240,7 @@ function playNoteColumn({
         bpm,
         when: Math.max(
           0,
-          scheduledStartTime -
-            audioContext.currentTime +
-            chordDelayMultiplier * notesPlayedSoFar,
+          baseWhen + chordDelayMultiplier * notesPlayedSoFar,
         ),
         // ^ makes sure that the proper delay is applied to each note in a chord
         // regardless of the number/spacing of notes in the chord

--- a/src/utils/playGeneratedAudioHelpers.ts
+++ b/src/utils/playGeneratedAudioHelpers.ts
@@ -1,6 +1,48 @@
 import extractNumber from "~/utils/extractNumber";
 import type Soundfont from "soundfont-player";
 
+export type StoppablePlaybackNode = { stop(when?: number): void };
+
+export function registerScheduledPlaybackNode(
+  scheduledNodes: StoppablePlaybackNode[] | undefined,
+  node: StoppablePlaybackNode | null | undefined,
+) {
+  if (scheduledNodes && node) {
+    scheduledNodes.push(node);
+  }
+}
+
+export function stopAllScheduledPlaybackNodes(
+  scheduledNodes: StoppablePlaybackNode[],
+  stopTime: number,
+) {
+  for (const node of scheduledNodes) {
+    try {
+      node.stop(stopTime);
+    } catch {
+      // Node may already have stopped.
+    }
+  }
+}
+
+export function stopActivePlaybackStrings(
+  activePlaybackStrings:
+    | (Soundfont.Player | AudioBufferSourceNode | undefined)[]
+    | null
+    | undefined,
+  stopTime: number,
+) {
+  if (!activePlaybackStrings) return;
+
+  for (const activeString of activePlaybackStrings) {
+    try {
+      activeString?.stop(stopTime);
+    } catch {
+      // Node may already have stopped.
+    }
+  }
+}
+
 interface PlayNoteWithEffects {
   note: GainNode;
   stringIdx: number;
@@ -17,6 +59,7 @@ interface PlayNoteWithEffects {
     | AudioBufferSourceNode
     | undefined
   )[];
+  scheduledNodes?: StoppablePlaybackNode[];
 }
 
 function playNoteWithEffects({
@@ -31,6 +74,7 @@ function playNoteWithEffects({
   audioContext,
   masterVolumeGainNode,
   currentlyPlayingStrings,
+  scheduledNodes,
 }: PlayNoteWithEffects) {
   let noteWithEffectApplied = undefined;
 
@@ -53,6 +97,7 @@ function playNoteWithEffects({
         isArbitrarySlide: tetheredMetadata.effect === "arbitrarySlide",
         audioContext,
         currentlyPlayingStrings,
+        scheduledNodes,
         isPalmMuted: effects?.includes("PM"),
       });
     } else if (tetheredMetadata.transitionFromFret !== undefined) {
@@ -68,6 +113,7 @@ function playNoteWithEffects({
         tetheredMetadata,
         audioContext,
         currentlyPlayingStrings,
+        scheduledNodes,
         isPalmMuted: effects?.includes("PM"),
       });
     }
@@ -83,6 +129,7 @@ function playNoteWithEffects({
         pluckBaseNote,
         audioContext,
         currentlyPlayingStrings,
+        scheduledNodes,
       });
     }
   }
@@ -127,6 +174,7 @@ interface ApplyBendEffect {
     | undefined
   )[];
   isPalmMuted?: boolean;
+  scheduledNodes?: StoppablePlaybackNode[];
 }
 
 function applyBendOrReleaseEffect({
@@ -142,6 +190,7 @@ function applyBendOrReleaseEffect({
   audioContext,
   currentlyPlayingStrings,
   isPalmMuted,
+  scheduledNodes,
 }: ApplyBendEffect) {
   let source: AudioBufferSourceNode | undefined = undefined;
   let sourceGain: GainNode | undefined = undefined;
@@ -165,6 +214,7 @@ function applyBendOrReleaseEffect({
       0.5,
       isPalmMuted ? 0.45 : undefined,
     );
+    registerScheduledPlaybackNode(scheduledNodes, source);
 
     sourceGain.gain.setValueAtTime(0.01, audioContext.currentTime + when);
     sourceGain.gain.linearRampToValueAtTime(
@@ -248,7 +298,7 @@ interface PlayDeadNote {
     | AudioBufferSourceNode
     | undefined
   )[];
-  scheduledNodes?: { stop(when?: number): void }[];
+  scheduledNodes?: StoppablePlaybackNode[];
 }
 
 function playDeadNote({
@@ -354,7 +404,7 @@ interface PlaySlapSound {
     | AudioBufferSourceNode
     | undefined
   )[];
-  scheduledNodes?: { stop(when?: number): void }[];
+  scheduledNodes?: StoppablePlaybackNode[];
 }
 
 function playSlapSound({
@@ -522,6 +572,7 @@ interface ApplyTetheredEffect {
     | undefined
   )[];
   isPalmMuted?: boolean;
+  scheduledNodes?: StoppablePlaybackNode[];
 }
 
 function applyTetheredEffect({
@@ -537,6 +588,7 @@ function applyTetheredEffect({
   audioContext,
   currentlyPlayingStrings,
   isPalmMuted,
+  scheduledNodes,
 }: ApplyTetheredEffect) {
   // immediately stop current note because we don't ever want to hear the pluck on
   // a tethered note
@@ -563,6 +615,7 @@ function applyTetheredEffect({
     tetheredEffect === "p" ? 0 : tetheredEffect === "h" ? 0.1 : 0.2,
     isPalmMuted ? 0.45 : undefined,
   );
+  registerScheduledPlaybackNode(scheduledNodes, source);
 
   sourceGain.gain.setValueAtTime(0.01, audioContext.currentTime + when);
   sourceGain.gain.linearRampToValueAtTime(
@@ -592,6 +645,7 @@ function applyTetheredEffect({
         bpm,
         audioContext,
         currentlyPlayingStrings,
+        scheduledNodes,
       });
     } else if (
       currentEffects.includes("b") &&
@@ -606,6 +660,7 @@ function applyTetheredEffect({
         bpm,
         audioContext,
         currentlyPlayingStrings,
+        scheduledNodes,
       });
     }
   }
@@ -626,6 +681,7 @@ interface ApplyVibratoEffect {
     | AudioBufferSourceNode
     | undefined
   )[];
+  scheduledNodes?: StoppablePlaybackNode[];
 }
 
 function applyVibratoEffect({
@@ -637,6 +693,7 @@ function applyVibratoEffect({
   pluckBaseNote = true,
   audioContext,
   currentlyPlayingStrings,
+  scheduledNodes,
 }: ApplyVibratoEffect) {
   let source: AudioBufferSourceNode | undefined = undefined;
   let sourceGain: GainNode | undefined = undefined;
@@ -655,6 +712,7 @@ function applyVibratoEffect({
     // @ts-expect-error TODO: fix type
     source.buffer = note.source.buffer as AudioBuffer;
     source.start(audioContext.currentTime + when, 0.5);
+    registerScheduledPlaybackNode(scheduledNodes, source);
 
     sourceGain.gain.setValueAtTime(0.01, audioContext.currentTime + when);
     sourceGain.gain.exponentialRampToValueAtTime(
@@ -678,6 +736,7 @@ function applyVibratoEffect({
 
   const oscillatorDelay = (60 / bpm) * 0.15;
   vibratoOscillator.start(audioContext.currentTime + when + oscillatorDelay);
+  registerScheduledPlaybackNode(scheduledNodes, vibratoOscillator);
 
   if (source && sourceGain) {
     vibratoDepth.connect(source.detune);
@@ -714,6 +773,7 @@ interface PlayNote {
     | undefined
   )[];
   acousticSteelOverrideForPreview?: Soundfont.Player;
+  scheduledNodes?: StoppablePlaybackNode[];
 }
 
 function playNote({
@@ -730,6 +790,7 @@ function playNote({
   masterVolumeGainNode,
   currentlyPlayingStrings,
   acousticSteelOverrideForPreview,
+  scheduledNodes,
 }: PlayNote) {
   let duration = 3;
   let gain = 1;
@@ -779,6 +840,11 @@ function playNote({
     },
   );
 
+  registerScheduledPlaybackNode(
+    scheduledNodes,
+    note as StoppablePlaybackNode | null | undefined,
+  );
+
   if (note && (tetheredMetadata || effects.length > 0)) {
     playNoteWithEffects({
       note: note as unknown as GainNode,
@@ -792,6 +858,7 @@ function playNote({
       audioContext,
       masterVolumeGainNode,
       currentlyPlayingStrings,
+      scheduledNodes,
     });
   }
 
@@ -867,7 +934,8 @@ interface PlayNoteColumn {
   strumDelayMultiplierScale?: number;
   acousticSteelOverrideForPreview?: Soundfont.Player;
   forTuningPreview?: boolean;
-  scheduledNodes?: { stop(when?: number): void }[];
+  scheduledNodes?: StoppablePlaybackNode[];
+  isSessionValid?: () => boolean;
 }
 
 function playNoteColumn({
@@ -1252,6 +1320,7 @@ function playNoteColumn({
         masterVolumeGainNode,
         currentlyPlayingStrings,
         acousticSteelOverrideForPreview,
+        scheduledNodes,
       });
 
       notesPlayedSoFar++;

--- a/src/utils/playbackScheduler.ts
+++ b/src/utils/playbackScheduler.ts
@@ -1,0 +1,344 @@
+import type Soundfont from "soundfont-player";
+import {
+  noteLengthMultipliers,
+  type FullNoteLengths,
+} from "~/stores/TabStore";
+import { playNoteColumn } from "~/utils/playGeneratedAudioHelpers";
+
+export const PLAYBACK_SCHEDULE_LOOKAHEAD_SECONDS = 1.0;
+
+export const PLAYBACK_START_EPSILON_SECONDS = 0.03;
+
+const SCHEDULER_POLL_INTERVAL_MS = 25;
+
+export interface PlaybackTimelineEntry {
+  chordIndex: number;
+  adjChordIndex: number;
+  startTime: number | null;
+  duration: number;
+  effectiveBpm: number;
+  thirdPrevColumn?: string[];
+  secondPrevColumn?: string[];
+  prevColumn?: string[];
+  currColumn: string[];
+  nextColumn?: string[];
+  isLastInCompiledSequence: boolean;
+}
+
+export interface BuildPlaybackTimelineArgs {
+  compiledChords: string[][];
+  fromChordIndex: number;
+  adjChordCount: number;
+  playbackSpeed: number;
+  startTime: number;
+}
+
+export function buildPlaybackTimeline({
+  compiledChords,
+  fromChordIndex,
+  adjChordCount,
+  playbackSpeed,
+  startTime,
+}: BuildPlaybackTimelineArgs): PlaybackTimelineEntry[] {
+  const entries: PlaybackTimelineEntry[] = [];
+  let nextStartTime = startTime;
+
+  for (let chordIndex = fromChordIndex; chordIndex < adjChordCount; chordIndex++) {
+    const adjChordIndex = chordIndex % compiledChords.length;
+    const currColumn = compiledChords[adjChordIndex];
+
+    let entryStartTime: number | null = null;
+    let duration = 0;
+    let effectiveBpm = 0;
+
+    if (currColumn && currColumn.length > 0) {
+      const noteLengthMultiplier =
+        noteLengthMultipliers[currColumn[8] as FullNoteLengths];
+      const baseBpm = Number(currColumn[9]);
+      effectiveBpm = baseBpm * (1 / noteLengthMultiplier) * playbackSpeed;
+      duration = 60 / effectiveBpm;
+      entryStartTime = nextStartTime;
+      nextStartTime += duration;
+    }
+
+    entries.push({
+      chordIndex,
+      adjChordIndex,
+      startTime: entryStartTime,
+      duration,
+      effectiveBpm,
+      thirdPrevColumn: compiledChords[adjChordIndex - 3],
+      secondPrevColumn: compiledChords[adjChordIndex - 2],
+      prevColumn: compiledChords[adjChordIndex - 1],
+      currColumn: currColumn ?? [],
+      nextColumn: compiledChords[adjChordIndex + 1],
+      isLastInCompiledSequence: adjChordIndex === compiledChords.length - 1,
+    });
+  }
+
+  return entries;
+}
+
+function getEntryCompletionTime(
+  entry: PlaybackTimelineEntry,
+  previousCompletionTime: number,
+): number {
+  if (entry.startTime !== null) {
+    return entry.startTime + entry.duration;
+  }
+
+  return previousCompletionTime;
+}
+
+export function sleepUntilAudioTime(
+  audioContext: AudioContext,
+  targetTime: number,
+  isCancelled: () => boolean,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const check = () => {
+      if (isCancelled()) {
+        resolve();
+        return;
+      }
+
+      if (audioContext.currentTime >= targetTime) {
+        resolve();
+        return;
+      }
+
+      setTimeout(check, SCHEDULER_POLL_INTERVAL_MS);
+    };
+
+    check();
+  });
+}
+
+export interface RunPlaybackSchedulerArgs {
+  compiledChords: string[][];
+  adjChordCount: number;
+  startChordIndex: number;
+  playbackStartTime: number;
+  playbackSpeed: number;
+  tuning: number[];
+  capo: number;
+  audioContext: AudioContext;
+  masterVolumeGainNode: GainNode;
+  currentInstrument: Soundfont.Player | null;
+  currentlyPlayingStrings: (
+    | Soundfont.Player
+    | AudioBufferSourceNode
+    | undefined
+  )[];
+  scheduledNodes?: { stop(when?: number): void }[];
+  playbackSessionId: number;
+  editing: boolean;
+  isSessionValid: () => boolean;
+  getState: () => {
+    breakOnNextChord: boolean;
+    looping: boolean;
+    showPlaybackModal: boolean;
+    audioMetadata: { playing: boolean };
+  };
+  setState: (partial: Record<string, unknown>) => void;
+  resetProgressTabSliderPosition: (mode: "editing" | "playback") => void;
+  clearBreakOnNextChord: () => void;
+}
+
+export async function runPlaybackScheduler({
+  compiledChords,
+  adjChordCount,
+  startChordIndex,
+  playbackStartTime,
+  playbackSpeed,
+  tuning,
+  capo,
+  audioContext,
+  masterVolumeGainNode,
+  currentInstrument,
+  currentlyPlayingStrings,
+  scheduledNodes,
+  isSessionValid,
+  getState,
+  setState,
+  resetProgressTabSliderPosition,
+  clearBreakOnNextChord,
+  editing,
+}: RunPlaybackSchedulerArgs): Promise<void> {
+  let timeline = buildPlaybackTimeline({
+    compiledChords,
+    fromChordIndex: startChordIndex,
+    adjChordCount,
+    playbackSpeed,
+    startTime: playbackStartTime,
+  });
+
+  let scheduledIndex = 0;
+  let processedIndex = 0;
+  let lastCompletionTime = playbackStartTime;
+  let timelineAnchorTime = playbackStartTime;
+  let segmentEndTime = playbackStartTime;
+
+  for (const entry of timeline) {
+    if (entry.startTime !== null) {
+      segmentEndTime = entry.startTime + entry.duration;
+    }
+  }
+
+  while (isSessionValid()) {
+    const now = audioContext.currentTime;
+    const horizon = now + PLAYBACK_SCHEDULE_LOOKAHEAD_SECONDS;
+
+    let uiPreviousCompletion = timelineAnchorTime;
+
+    for (let index = 0; index < timeline.length; index++) {
+      const entry = timeline[index]!;
+      const completionTime = getEntryCompletionTime(entry, uiPreviousCompletion);
+
+      if (entry.startTime !== null) {
+        if (entry.startTime <= now) {
+          setState({ currentChordIndex: entry.chordIndex });
+          uiPreviousCompletion = completionTime;
+        } else {
+          break;
+        }
+      } else if (completionTime <= now) {
+        setState({ currentChordIndex: entry.chordIndex });
+        uiPreviousCompletion = completionTime;
+      } else {
+        break;
+      }
+    }
+
+    while (scheduledIndex < timeline.length && isSessionValid()) {
+      const entry = timeline[scheduledIndex]!;
+
+      if (entry.startTime !== null && entry.startTime > horizon) {
+        break;
+      }
+
+      if (entry.startTime !== null && entry.currColumn.length > 0) {
+        void playNoteColumn({
+          tuning,
+          capo,
+          bpm: entry.effectiveBpm,
+          targetStartTime: entry.startTime,
+          thirdPrevColumn: entry.thirdPrevColumn,
+          secondPrevColumn: entry.secondPrevColumn,
+          prevColumn: entry.prevColumn,
+          currColumn: entry.currColumn,
+          nextColumn: entry.nextColumn,
+          audioContext,
+          masterVolumeGainNode,
+          currentInstrument,
+          currentlyPlayingStrings,
+          scheduledNodes,
+        });
+      }
+
+      scheduledIndex++;
+    }
+
+    while (processedIndex < timeline.length && isSessionValid()) {
+      const entry = timeline[processedIndex]!;
+      const completionTime = getEntryCompletionTime(entry, lastCompletionTime);
+
+      if (now < completionTime) {
+        break;
+      }
+
+      if (entry.isLastInCompiledSequence) {
+        resetProgressTabSliderPosition(editing ? "editing" : "playback");
+      }
+
+      const { breakOnNextChord } = getState();
+
+      if (breakOnNextChord) {
+        clearBreakOnNextChord();
+        return;
+      }
+
+      lastCompletionTime = completionTime;
+      processedIndex++;
+    }
+
+    if (processedIndex >= timeline.length) {
+      const lastEntry = timeline[timeline.length - 1];
+      const { looping, showPlaybackModal, audioMetadata } = getState();
+
+      if (
+        lastEntry &&
+        lastEntry.chordIndex === adjChordCount - 1 &&
+        (looping || showPlaybackModal) &&
+        audioMetadata.playing &&
+        isSessionValid()
+      ) {
+        setState({ currentChordIndex: 0 });
+
+        timeline = buildPlaybackTimeline({
+          compiledChords,
+          fromChordIndex: 0,
+          adjChordCount,
+          playbackSpeed,
+          startTime: segmentEndTime,
+        });
+
+        scheduledIndex = 0;
+        processedIndex = 0;
+        lastCompletionTime = segmentEndTime;
+        timelineAnchorTime = segmentEndTime;
+
+        segmentEndTime = segmentEndTime;
+        for (const entry of timeline) {
+          if (entry.startTime !== null) {
+            segmentEndTime = entry.startTime + entry.duration;
+          }
+        }
+
+        continue;
+      }
+
+      if (
+        lastEntry &&
+        lastEntry.chordIndex === adjChordCount - 1 &&
+        !looping
+      ) {
+        setState({
+          currentChordIndex: 0,
+          playbackStartedAtAudioTime: null,
+          audioMetadata: {
+            ...audioMetadata,
+            playing: false,
+          },
+        });
+      }
+
+      return;
+    }
+
+    const nextUnscheduledEntry = timeline[scheduledIndex];
+    const nextUnprocessedEntry = timeline[processedIndex];
+
+    let wakeTime = now + SCHEDULER_POLL_INTERVAL_MS / 1000;
+
+    if (
+      nextUnscheduledEntry &&
+      nextUnscheduledEntry.startTime !== null &&
+      nextUnscheduledEntry.startTime !== undefined
+    ) {
+      const scheduleWake =
+        nextUnscheduledEntry.startTime - PLAYBACK_SCHEDULE_LOOKAHEAD_SECONDS;
+      wakeTime = Math.min(wakeTime, scheduleWake);
+    }
+
+    if (nextUnprocessedEntry) {
+      const processWake = getEntryCompletionTime(
+        nextUnprocessedEntry,
+        lastCompletionTime,
+      );
+      wakeTime = Math.min(wakeTime, processWake);
+    }
+
+    await sleepUntilAudioTime(audioContext, wakeTime, () => !isSessionValid());
+  }
+}

--- a/src/utils/playbackScheduler.ts
+++ b/src/utils/playbackScheduler.ts
@@ -167,6 +167,7 @@ export interface RunPlaybackSchedulerArgs {
     | undefined
   )[];
   scheduledNodes?: { stop(when?: number): void }[];
+  isSessionValid?: () => boolean;
   playbackSessionId: number;
   editing: boolean;
   isSessionValid: () => boolean;

--- a/src/utils/playbackScheduler.ts
+++ b/src/utils/playbackScheduler.ts
@@ -10,6 +10,7 @@ export const PLAYBACK_SCHEDULE_LOOKAHEAD_SECONDS = 1.0;
 export const PLAYBACK_START_EPSILON_SECONDS = 0.03;
 
 const SCHEDULER_POLL_INTERVAL_MS = 25;
+const MIN_SCHEDULER_SLEEP_SECONDS = SCHEDULER_POLL_INTERVAL_MS / 1000;
 
 export interface PlaybackTimelineEntry {
   chordIndex: number;
@@ -90,6 +91,41 @@ function getEntryCompletionTime(
   return previousCompletionTime;
 }
 
+function getActiveChordIndexForTime(
+  timeline: PlaybackTimelineEntry[],
+  now: number,
+  timelineAnchorTime: number,
+): number | null {
+  if (timeline.length === 0) return null;
+
+  let previousCompletionTime = timelineAnchorTime;
+  let activeChordIndex = timeline[0]!.chordIndex;
+
+  for (const entry of timeline) {
+    if (entry.startTime !== null) {
+      if (entry.startTime <= now) {
+        activeChordIndex = entry.chordIndex;
+        previousCompletionTime = entry.startTime + entry.duration;
+        continue;
+      }
+
+      break;
+    }
+
+    const completionTime = getEntryCompletionTime(entry, previousCompletionTime);
+
+    if (completionTime <= now) {
+      activeChordIndex = entry.chordIndex;
+      previousCompletionTime = completionTime;
+      continue;
+    }
+
+    break;
+  }
+
+  return activeChordIndex;
+}
+
 export function sleepUntilAudioTime(
   audioContext: AudioContext,
   targetTime: number,
@@ -139,6 +175,7 @@ export interface RunPlaybackSchedulerArgs {
     looping: boolean;
     showPlaybackModal: boolean;
     audioMetadata: { playing: boolean };
+    currentChordIndex: number;
   };
   setState: (partial: Record<string, unknown>) => void;
   resetProgressTabSliderPosition: (mode: "editing" | "playback") => void;
@@ -178,6 +215,7 @@ export async function runPlaybackScheduler({
   let lastCompletionTime = playbackStartTime;
   let timelineAnchorTime = playbackStartTime;
   let segmentEndTime = playbackStartTime;
+  let lastReportedChordIndex = getState().currentChordIndex;
 
   for (const entry of timeline) {
     if (entry.startTime !== null) {
@@ -185,30 +223,25 @@ export async function runPlaybackScheduler({
     }
   }
 
+  const maybeUpdateCurrentChordIndex = (nextChordIndex: number | null) => {
+    if (
+      nextChordIndex === null ||
+      nextChordIndex === lastReportedChordIndex
+    ) {
+      return;
+    }
+
+    lastReportedChordIndex = nextChordIndex;
+    setState({ currentChordIndex: nextChordIndex });
+  };
+
   while (isSessionValid()) {
     const now = audioContext.currentTime;
     const horizon = now + PLAYBACK_SCHEDULE_LOOKAHEAD_SECONDS;
 
-    let uiPreviousCompletion = timelineAnchorTime;
-
-    for (let index = 0; index < timeline.length; index++) {
-      const entry = timeline[index]!;
-      const completionTime = getEntryCompletionTime(entry, uiPreviousCompletion);
-
-      if (entry.startTime !== null) {
-        if (entry.startTime <= now) {
-          setState({ currentChordIndex: entry.chordIndex });
-          uiPreviousCompletion = completionTime;
-        } else {
-          break;
-        }
-      } else if (completionTime <= now) {
-        setState({ currentChordIndex: entry.chordIndex });
-        uiPreviousCompletion = completionTime;
-      } else {
-        break;
-      }
-    }
+    maybeUpdateCurrentChordIndex(
+      getActiveChordIndexForTime(timeline, now, timelineAnchorTime),
+    );
 
     while (scheduledIndex < timeline.length && isSessionValid()) {
       const entry = timeline[scheduledIndex]!;
@@ -239,27 +272,25 @@ export async function runPlaybackScheduler({
       scheduledIndex++;
     }
 
-    while (processedIndex < timeline.length && isSessionValid()) {
+    if (processedIndex < timeline.length && isSessionValid()) {
       const entry = timeline[processedIndex]!;
       const completionTime = getEntryCompletionTime(entry, lastCompletionTime);
 
-      if (now < completionTime) {
-        break;
+      if (now >= completionTime) {
+        if (entry.isLastInCompiledSequence) {
+          resetProgressTabSliderPosition(editing ? "editing" : "playback");
+        }
+
+        const { breakOnNextChord } = getState();
+
+        if (breakOnNextChord) {
+          clearBreakOnNextChord();
+          return;
+        }
+
+        lastCompletionTime = completionTime;
+        processedIndex++;
       }
-
-      if (entry.isLastInCompiledSequence) {
-        resetProgressTabSliderPosition(editing ? "editing" : "playback");
-      }
-
-      const { breakOnNextChord } = getState();
-
-      if (breakOnNextChord) {
-        clearBreakOnNextChord();
-        return;
-      }
-
-      lastCompletionTime = completionTime;
-      processedIndex++;
     }
 
     if (processedIndex >= timeline.length) {
@@ -273,7 +304,7 @@ export async function runPlaybackScheduler({
         audioMetadata.playing &&
         isSessionValid()
       ) {
-        setState({ currentChordIndex: 0 });
+        maybeUpdateCurrentChordIndex(0);
 
         timeline = buildPlaybackTimeline({
           compiledChords,
@@ -319,7 +350,7 @@ export async function runPlaybackScheduler({
     const nextUnscheduledEntry = timeline[scheduledIndex];
     const nextUnprocessedEntry = timeline[processedIndex];
 
-    let wakeTime = now + SCHEDULER_POLL_INTERVAL_MS / 1000;
+    let wakeTime = now + MIN_SCHEDULER_SLEEP_SECONDS;
 
     if (
       nextUnscheduledEntry &&
@@ -338,6 +369,8 @@ export async function runPlaybackScheduler({
       );
       wakeTime = Math.min(wakeTime, processWake);
     }
+
+    wakeTime = Math.max(now + MIN_SCHEDULER_SLEEP_SECONDS, wakeTime);
 
     await sleepUntilAudioTime(audioContext, wakeTime, () => !isSessionValid());
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the sequential `await`-per-chord loop in `playTab()` with a Web Audio lookahead scheduler that pre-schedules chords up to **1 second** ahead of `audioContext.currentTime`. This prevents late chord playback at high BPM or under main-thread pressure.

## Changes

- **New [`src/utils/playbackScheduler.ts`](src/utils/playbackScheduler.ts)**
  - `PLAYBACK_SCHEDULE_LOOKAHEAD_SECONDS = 1.0` (tunable constant)
  - `buildPlaybackTimeline()` — precomputes absolute start times per chord
  - `runPlaybackScheduler()` — fills the lookahead buffer, syncs UI index to the audio clock, and preserves loop/pause/end behavior

- **[`src/stores/TabStore.ts`](src/stores/TabStore.ts)**
  - `playTab()` delegates to the scheduler instead of awaiting each chord sequentially
  - Adds `playbackSessionId` and `scheduledPlaybackNodes` for session invalidation on pause
  - `pauseAudio()` increments the session ID, stops tracked oscillator/buffer nodes, and clears the queue

- **[`src/utils/playGeneratedAudioHelpers.ts`](src/utils/playGeneratedAudioHelpers.ts)**
  - `playDeadNote` / `playSlapSound` accept a `when` offset and schedule all WAAPI events at `currentTime + when`
  - String `stop()` calls deferred via `setTimeout(when * 1000)` to avoid silencing notes from earlier chords when pre-scheduling
  - Rest (`r`) stops deferred similarly
  - Tethered/bend/vibrato paths fixed to use `currentTime + when` instead of immediate `stop(0)` / `start(0, ...)`

## WAAPI notes

Soundfont notes already supported future scheduling via `when`. The main gaps were dead notes, slaps, rest stops, and tethered-effect source stops — all now aligned with absolute schedule times. Pause invalidates the scheduler session and stops pre-scheduled percussive nodes; soundfont notes are cancelled via `currentInstrument.stop()`.

## Manual verification

- [ ] Fast tab (200+ BPM) — chords stay aligned with scrolling strip
- [ ] Tabs with dead notes (`x`) and slaps (`s`) — sounds fire at chord time, not early
- [ ] Pause mid-song → resume from `currentChordIndex` without ghost chords
- [ ] Pause → change loop range/section → play starts fresh
- [ ] Tethered effects (h/p slides) at high BPM still sound correct

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f5eb32c-7efd-43f6-8c95-ea17b4ff0e97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f5eb32c-7efd-43f6-8c95-ea17b4ff0e97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

